### PR TITLE
20160831 031700 polling motor driver

### DIFF
--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -218,7 +218,7 @@ class CNCDriver(object):
             for axis in coords.get('target', {}):
                 axis_diff = coords['current'][axis] - coords['target'][axis]
                 # smoothie not guaranteed to be EXACTLY where it's target is
-                # but could about +=0.05 mm from the target coordinate
+                # but could about +-0.05 mm from the target coordinate
                 if abs(axis_diff) < 0.1:
                     if coords['current'][axis] == prev_coords['current'][axis]:
                         arrived = True

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -237,7 +237,10 @@ class CNCDriver(object):
         res = self.send_command(home_command + axis_homed)
         if res == b'ok':
             # the axis aren't necessarily set to 0.0 values after homing, so force it
-            return self.set_position(x=0, y=0, z=0, a=0, b=0)
+            pos_args = {}
+            for l in axis_homed:
+                pos_args[l] = 0
+            return self.set_position(**pos_args)
         else:
             return False
 

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -141,6 +141,9 @@ class CNCDriver(object):
                             "Waiting {} lines for \"ok\"."
                             .format(count)
                         )
+
+            # TODO (andy):  here we should poll smoothie with `M114` 
+            #               until it's coordinates match what was sent
             return out
         elif max_tries > 0:
             time.sleep(try_interval)

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -48,8 +48,7 @@ class CNCDriver(object):
     This object outputs raw GCode commands to perform high-level tasks.
     """
 
-    RAPID_MOVE = 'G0'
-    MOVE = 'G1'
+    MOVE = 'G0'
     DWELL = 'G4'
     HOME = 'G28'
     SET_POSITION = 'G92'
@@ -64,8 +63,7 @@ class CNCDriver(object):
     UNITS_TO_INCHES = 'G20'
     UNITS_TO_MILLIMETERS = 'G22'
 
-    DEBUG_ON = None
-    DEBUG_OFF = None
+    VERSION = None
 
     """
     If simulated is set to true, all GCode commands will be saved to an
@@ -167,10 +165,7 @@ class CNCDriver(object):
 
     def move(self, x=None, y=None, z=None, speed=None, absolute=True, **kwargs):
 
-        if speed:
-            code = self.MOVE
-        else:
-            code = self.RAPID_MOVE
+        code = self.MOVE
 
         if absolute:
             self.send_command(self.ABSOLUTE_POSITIONING)
@@ -233,8 +228,7 @@ class CNCDriver(object):
 
 class OpenTrons(CNCDriver):
 
-    DEBUG_ON = 'M62'
-    DEBUG_OFF = 'M63'
+    VERSION = 'version'
 
 
 class MoveLogger(CNCDriver):

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -118,7 +118,7 @@ class CNCDriver(object):
 
         args = []
         for key in kwargs:
-            args.append("%s%d" % (key.upper(), kwargs[key]))
+            args.append("%s%d" % (key, kwargs[key]))
 
         command = command + " " + ' '.join(args) + "\r\n"
 
@@ -194,11 +194,11 @@ class CNCDriver(object):
         them as anonymous parameters when calling this method.
         """
         if x is not None:
-            args['x'] = x
+            args['X'] = x
         if y is not None:
-            args['y'] = y
+            args['Y'] = y
         if z is not None:
-            args['z'] = z
+            args['Z'] = z
 
         for k in kwargs:
             args[k.upper()] = kwargs[k]
@@ -221,8 +221,8 @@ class CNCDriver(object):
                     break
         return arrived
 
-    def home(self):
-        res = self.send_command(self.HOME)
+    def home(self, **kwargs):
+        res = self.send_command(self.HOME, **kwargs)
         if res == b'ok':
             # the axis aren't necessarily set to 0.0 values after homing, so force it
             return self.set_position(x=0, y=0, z=0, a=0, b=0)
@@ -232,7 +232,7 @@ class CNCDriver(object):
     def wait(self, sec):
         ms = int((sec % 1.0) * 1000)
         s = int(sec)
-        res = self.send_command(self.DWELL, s=s, p=ms)
+        res = self.send_command(self.DWELL, S=s, P=ms)
         return res == b'ok'
 
     def halt(self):
@@ -244,7 +244,10 @@ class CNCDriver(object):
         return res == b'ok'
 
     def set_position(self, **kwargs):
-        res = self.send_command(self.SET_POSITION, **kwargs)
+        uppercase_args = {}
+        for key in kwargs:
+            uppercase_args[key.upper()] = kwargs[key]
+        res = self.send_command(self.SET_POSITION, **uppercase_args)
         return res == b'ok'
 
     def get_position(self):

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -87,7 +87,7 @@ class CNCDriver(object):
         self.command_queue = []
 
     def connect(self, device=None, port=None):
-        self.connection = serial.Serial(port=device or port)
+        self.connection = serial.Serial(port=device or port, baudrate=115200, timeout=0.1)
         self.connection.close()
         self.connection.open()
         log.debug("Serial", "Connected to {}".format(device or port))

--- a/tests/opentrons_sdk/drivers/motor_test.py
+++ b/tests/opentrons_sdk/drivers/motor_test.py
@@ -5,7 +5,7 @@ from opentrons_sdk.drivers.motor import OpenTrons, GCodeLogger
 class SerialTestCase(unittest.TestCase):
 
     def assertLastCommand(self, *commands):
-        lastCommand = self.motor.connection.write_buffer[-1]
+        lastCommand = self.motor.connection.write_buffer[-1].decode("utf-8") 
         foundOne = False
         for command in commands:
             if lastCommand.startswith(command):
@@ -24,7 +24,7 @@ class SerialTestCase(unittest.TestCase):
         self.assertTrue(foundOne, msg=msg)
 
     def assertLastArguments(self, *arguments):
-        lastCommand = self.motor.connection.write_buffer[-1]
+        lastCommand = self.motor.connection.write_buffer[-1].decode("utf-8") 
         for arg in arguments:
             msg = "Expected last command arguments to include " + \
                   "\"" + arg + "\" but got \"" + lastCommand.strip() +\

--- a/tests/opentrons_sdk/drivers/motor_test.py
+++ b/tests/opentrons_sdk/drivers/motor_test.py
@@ -39,7 +39,7 @@ class OpenTronsTest(SerialTestCase):
         # set this to True if testing with a robot connected
         # testing while connected allows the response handlers
         # and serial handshakes to be tested
-        self.smoothie_connected = True
+        self.smoothie_connected = False
 
         self.motor = OpenTrons()
 
@@ -125,7 +125,7 @@ class OpenTronsTest(SerialTestCase):
             self.assertTrue(success)
         else:
             self.assertLastCommand('G999')
-            self.assertLastArguments('X1', 'Y2', 'Z3')
+            self.assertLastArguments('x1', 'y2', 'z3')
 
     def test_wait(self):
         success = self.motor.wait(1.234)

--- a/tests/opentrons_sdk/drivers/motor_test.py
+++ b/tests/opentrons_sdk/drivers/motor_test.py
@@ -39,7 +39,7 @@ class OpenTronsTest(SerialTestCase):
         # set this to True if testing with a robot connected
         # testing while connected allows the response handlers
         # and serial handshakes to be tested
-        self.smoothie_connected = False
+        self.smoothie_connected = True
 
         self.motor = OpenTrons()
 
@@ -79,11 +79,19 @@ class OpenTronsTest(SerialTestCase):
             self.assertLastCommand('M999')
 
     def test_home(self):
-        success = self.motor.home()
+        success = self.motor.home('x','y')
         if self.smoothie_connected:
             self.assertTrue(success)
         else:
-            self.assertLastCommand('G28',index=-2)
+            self.assertLastCommand('G28XY',index=-2)
+            self.assertLastCommand('G92')
+            self.assertLastArguments('X0', 'Y0', 'Z0', 'A0', 'B0')
+
+        success = self.motor.home('ba')
+        if self.smoothie_connected:
+            self.assertTrue(success)
+        else:
+            self.assertLastCommand('G28AB',index=-2)
             self.assertLastCommand('G92')
             self.assertLastArguments('X0', 'Y0', 'Z0', 'A0', 'B0')
 

--- a/tests/opentrons_sdk/drivers/motor_test.py
+++ b/tests/opentrons_sdk/drivers/motor_test.py
@@ -39,7 +39,7 @@ class OpenTronsTest(SerialTestCase):
         # set this to True if testing with a robot connected
         # testing while connected allows the response handlers
         # and serial handshakes to be tested
-        self.smoothie_connected = True
+        self.smoothie_connected = False
 
         self.motor = OpenTrons()
 

--- a/tests/opentrons_sdk/drivers/motor_test.py
+++ b/tests/opentrons_sdk/drivers/motor_test.py
@@ -35,46 +35,86 @@ class SerialTestCase(unittest.TestCase):
 class OpenTronsTest(SerialTestCase):
 
     def setUp(self):
+
+        self.connected = True
+
         self.motor = OpenTrons()
-        self.motor.connection = GCodeLogger()
+
+        if self.connected:
+            self.motor.connect('/dev/tty.usbmodem1421')
+        else:
+            self.motor.connection = GCodeLogger()
+
+    def tearDown(self):
+        self.motor.disconnect()
 
     def test_home(self):
-        self.motor.home()
-        self.assertLastCommand('G28')
+        res = self.motor.home()
+        if self.connected:
+            self.assertTrue(res.startswith(b'ok'))
+        else:
+            self.assertLastCommand('G28')
 
     def test_move_x(self):
-        self.motor.move(x=1)
-        self.assertLastCommand('G0', 'G1')
-        self.assertLastArguments('X1')
+        res = self.motor.move(x=100)
+        if self.connected:
+            self.assertTrue(res.startswith(b'ok'))
+        else:
+            self.assertLastCommand('G0', 'G1')
+            self.assertLastArguments('X100')
 
     def test_move_y(self):
-        self.motor.move(y=1)
-        self.assertLastCommand('G0', 'G1')
-        self.assertLastArguments('Y1')
+        res = self.motor.move(y=100)
+        if self.connected:
+            self.assertTrue(res.startswith(b'ok'))
+        else:
+            self.assertLastCommand('G0', 'G1')
+            self.assertLastArguments('Y100')
 
     def test_move_z(self):
-        self.motor.move(z=1)
-        self.assertLastCommand('G0', 'G1')
-        self.assertLastArguments('Z1')
+        res = self.motor.move(z=30)
+        if self.connected:
+            self.assertTrue(res.startswith(b'ok'))
+        else:
+            self.assertLastCommand('G0', 'G1')
+            self.assertLastArguments('Z30')
 
     def test_send_command(self):
-        self.motor.send_command('G999 X1 Y1 Z1')
-        self.assertLastCommand('G999')
-        self.assertLastArguments('X1', 'Y1', 'Z1')
+        res = self.motor.send_command('G999 X1 Y1 Z1')
+        if self.connected:
+            self.assertTrue(res.startswith(b'ok'))
+        else:
+            self.assertLastCommand('G999')
+            self.assertLastArguments('X1', 'Y1', 'Z1')
 
     def test_send_command_with_kwargs(self):
-        self.motor.send_command('G999', x=1, y=2, z=3)
-        self.assertLastCommand('G999')
-        self.assertLastArguments('X1', 'Y2', 'Z3')
+        res = self.motor.send_command('G999', x=1, y=2, z=3)
+        if self.connected:
+            self.assertTrue(res.startswith(b'ok'))
+        else:
+            self.assertLastCommand('G999')
+            self.assertLastArguments('X1', 'Y2', 'Z3')
 
     def test_wait(self):
-        self.motor.wait(1)
-        self.assertLastCommand('G4')
+        res = self.motor.wait(1)
+        if self.connected:
+            self.assertTrue(res.startswith(b'ok'))
+        else:
+            self.assertLastCommand('G4')
 
     def test_halt(self):
-        self.motor.halt()
-        self.assertLastCommand('M112')
+        res = self.motor.halt()
+        if self.connected:
+            self.assertTrue(res.startswith(b'ok'))
+        else:
+            self.assertLastCommand('M112')
+
+        # must resume before any other commands can be processed
+        self.motor.resume()
 
     def test_resume(self):
-        self.motor.resume()
-        self.assertLastCommand('M999')
+        res = self.motor.resume()
+        if self.connected:
+            self.assertTrue(res.startswith(b'ok'))
+        else:
+            self.assertLastCommand('M999')

--- a/tests/opentrons_sdk/drivers/motor_test.py
+++ b/tests/opentrons_sdk/drivers/motor_test.py
@@ -85,7 +85,7 @@ class OpenTronsTest(SerialTestCase):
         else:
             self.assertLastCommand('G28XY',index=-2)
             self.assertLastCommand('G92')
-            self.assertLastArguments('X0', 'Y0', 'Z0', 'A0', 'B0')
+            self.assertLastArguments('X0', 'Y0')
 
         success = self.motor.home('ba')
         if self.smoothie_connected:
@@ -93,7 +93,7 @@ class OpenTronsTest(SerialTestCase):
         else:
             self.assertLastCommand('G28AB',index=-2)
             self.assertLastCommand('G92')
-            self.assertLastArguments('X0', 'Y0', 'Z0', 'A0', 'B0')
+            self.assertLastArguments('A0', 'B0')
 
     def test_move_x(self):
         success = self.motor.move(x=100)


### PR DESCRIPTION
This PR moves the motor driver away from the OT forked firmware, and works as follows:

- When a gcode command is sent, driver returns only when `b"ok"` or similar is received from motor controller
- Current coordinates are polled using the `M114` "show current position" gcode command
    - The response includes the motor controller's target coordinates and it's real-time coordinates
- To detect when a series of move commands have completed, the `wait_for_arrival()` method compares the target coordinate to the real-time coordinate, and returns when they're equal