### PR TITLE
52 special gcodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ docs/_build/
 target/
 .idea/
 .setup_litter
+
+# Testing
+sample_protocol.py

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -65,6 +65,7 @@ class CNCDriver(object):
     GET_POSITION = 'M114'
     GET_ENDSTOPS = 'M119'
     GET_SPEED = 'M199'
+    SET_SPEED = 'G0'
     ACCELERATION = 'M204'
     MOTORS_ON = 'M17'
     MOTORS_OFF = 'M18'
@@ -284,7 +285,7 @@ class CNCDriver(object):
                 """
                 smoothie not guaranteed to be EXACTLY where it's target is
                 but seems to be about +-0.05 mm from the target coordinate
-                the robot's physical resolution is found with:  1mm / config_steps_per_mm 
+                the robot's physical resolution is found with:  1mm / config_steps_per_mm
                 """
                 if abs(axis_diff) < 0.1:
                     if coords['current'][axis] == prev_coords['current'][axis]:
@@ -347,12 +348,17 @@ class CNCDriver(object):
 
             coords['current']['z'] = self.invert_z(coords['current']['z'])
             coords['target']['z'] = self.invert_z(coords['target']['z'])
-        
+
         except JSON_ERROR as e:
             log.debug("Serial", "Error parsing JSON string:")
             log.debug("Serial", res)
 
         return coords
+
+    def speed(self, axis, rate):
+        speed_command = self.SET_SPEED
+        res = self.send_command(speed_command + axis + str(rate))
+
 
 
 class MoveLogger(CNCDriver):

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -355,7 +355,7 @@ class CNCDriver(object):
 
         return coords
 
-    def speed(self, axis, rate):
+    def instrument_speed(self, axis, rate):
         speed_command = self.SET_SPEED
         res = self.send_command(speed_command + axis + str(rate))
 

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -360,7 +360,6 @@ class CNCDriver(object):
         res = self.send_command(speed_command + axis + str(rate))
 
 
-
 class MoveLogger(CNCDriver):
 
     """

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -391,9 +391,19 @@ class CNCDriver(object):
 
         return coords
 
-    def instrument_speed(self, axis, rate):
+    def speed(self, rate, axis=None):
         speed_command = self.SET_SPEED
-        res = self.send_command(speed_command + axis + str(rate))
+
+        if axis:
+            #AB speeds - per axis
+            res = self.send_command(speed_command + axis + str(rate))
+        else:
+            #XYZ speeds - for all axis
+            res = self.send_command(speed_command + "F" + str(rate))
+
+        return res == b'ok'
+
+
     def get_ot_version(self):
         res = self.send_command(self.GET_OT_VERSION)
         self.ot_version = res.decode().split(' ')[-1]

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -11,7 +11,8 @@ class Pipette(object):
             channels=1,
             min_volume=0,
             trash_container=None,
-            tip_racks=None):
+            tip_racks=None,
+            speed=300):
 
         self.positions = {
             'top': None,
@@ -38,6 +39,8 @@ class Pipette(object):
         self.placeables = []
 
         self.calibrator = Calibrator()
+
+        self.set_speed(speed)
 
     def go_to(self, location):
         if location:
@@ -246,6 +249,13 @@ class Pipette(object):
             self.motor.wait(seconds)
 
         description = "Delaying {} seconds".format(seconds)
+        self.robot.add_command(Command(do=_do, description=description))
+
+    def set_speed(self, rate):
+        def _do():
+            self.motor.speed(rate)
+
+        description = "Setting speed to {}mm/second".format(rate)
         self.robot.add_command(Command(do=_do, description=description))
 
     @property

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -41,6 +41,7 @@ class Pipette(object):
         self.calibrator = Calibrator()
 
         self.set_speed(speed)
+        self.speed = speed
 
     def go_to(self, location):
         if location:
@@ -252,11 +253,23 @@ class Pipette(object):
         self.robot.add_command(Command(do=_do, description=description))
 
     def set_speed(self, rate):
+        self.speed = rate
+
         def _do():
             self.motor.speed(rate)
 
         description = "Setting speed to {}mm/second".format(rate)
         self.robot.add_command(Command(do=_do, description=description))
+
+    def pause(self):
+        def _do():
+            print("Paused")
+
+        description = "Pausing"
+        self.robot.add_command(Command(do=_do, description=description))
+
+    def resume(self):
+        self.robot.run()
 
     @property
     def name(self):

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -258,9 +258,10 @@ class Pipette(object):
 
     def set_speed(self, rate):
         self.speed = rate
+        axis = self.axis
 
         def _do():
-            self.motor.speed(rate)
+            self.motor.speed(rate, axis)
 
         description = "Setting speed to {}mm/second".format(rate)
         self.robot.add_command(Command(do=_do, description=description))

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -41,7 +41,6 @@ class Pipette(object):
         self.calibrator = Calibrator()
 
         self.set_speed(speed)
-        self.speed = speed
 
     def go_to(self, location):
         if location:

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -241,6 +241,13 @@ class Pipette(object):
     def supports_volume(self, volume):
         return self.max_volume <= volume <= self.max_volume
 
+    def delay(self, seconds):
+        def _do():
+            self.motor.wait(seconds)
+
+        description = "Delaying {} seconds".format(seconds)
+        self.robot.add_command(Command(do=_do, description=description))
+
     @property
     def name(self):
         return self.size.lower()

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -266,16 +266,6 @@ class Pipette(object):
         description = "Setting speed to {}mm/second".format(rate)
         self.robot.add_command(Command(do=_do, description=description))
 
-    def pause(self):
-        def _do():
-            print("Paused")
-
-        description = "Pausing"
-        self.robot.add_command(Command(do=_do, description=description))
-
-    def resume(self):
-        self.robot.run()
-
     @property
     def name(self):
         return self.size.lower()

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -67,7 +67,7 @@ class Robot(object):
                 robot_self._driver.wait(seconds)
 
             def speed(self, rate):
-                robot_self._driver.speed(axis, rate)
+                robot_self._driver.instrument_speed(axis, rate)
                 return self
 
 

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -94,6 +94,9 @@ class Robot(object):
     def add_command(self, command):
         self._commands.append(command)
 
+    def add_command_to_beginning(self, command):
+        self._commands = [command] + self._commands
+
     def register(self, name, callback):
         def commandable():
             self.add_command(Command(do=callback))

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -63,6 +63,10 @@ class Robot(object):
             def wait_for_arrival(self):
                 return robot_self._driver.wait_for_arrival()
 
+            def wait(self, seconds):
+                robot_self._driver.wait(seconds)
+
+
         return InstrumentMotor()
 
     def list_serial_ports(self):

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -66,6 +66,11 @@ class Robot(object):
             def wait(self, seconds):
                 robot_self._driver.wait(seconds)
 
+            def speed(self, rate):
+                robot_self._driver.speed(axis, rate)
+                return self
+
+
 
         return InstrumentMotor()
 

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -229,3 +229,13 @@ class Robot(object):
         container = legacy_containers.get_legacy_container(container_name)
         self._deck[slot].add(container, container_name)
         return container
+
+    def pause(self):
+        def _do():
+            print("Paused")
+
+        description = "Pausing"
+        self.add_command(Command(do=_do, description=description))
+
+    def resume(self):
+        self.run()

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -66,8 +66,8 @@ class Robot(object):
             def wait(self, seconds):
                 robot_self._driver.wait(seconds)
 
-            def speed(self, rate):
-                robot_self._driver.instrument_speed(axis, rate)
+            def speed(self, rate, axis):
+                robot_self._driver.speed(rate, axis)
                 return self
 
 

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -94,7 +94,7 @@ class Robot(object):
     def add_command(self, command):
         self._commands.append(command)
 
-    def add_command_to_beginning(self, command):
+    def prepend_command(self, command):
         self._commands = [command] + self._commands
 
     def register(self, name, callback):
@@ -231,11 +231,13 @@ class Robot(object):
         return container
 
     def pause(self):
+        # This method is for API use only - in a user protocol, it will jump the
+        # queue, which is counterintuitive and not very useful.
         def _do():
             print("Paused")
 
         description = "Pausing"
-        self.add_command(Command(do=_do, description=description))
+        self.prepend_command(Command(do=_do, description=description))
 
     def resume(self):
         self.run()

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -1,4 +1,4 @@
-import copy
+import copy, time
 
 import opentrons_sdk.drivers.motor as motor_drivers
 from opentrons_sdk.containers import legacy_containers, placeable
@@ -69,7 +69,6 @@ class Robot(object):
             def speed(self, rate):
                 robot_self._driver.speed(axis, rate)
                 return self
-
 
 
         return InstrumentMotor()
@@ -147,6 +146,7 @@ class Robot(object):
         """
         while self._commands:
             command = self._commands.pop(0)
+            if command.description == "Pausing": return
             print("Executing: ", command.description)
             log.debug("Robot", command.description)
             command.do()

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -10,8 +10,7 @@ from opentrons_sdk.containers.placeable import unpack_location
 class PipetteTest(unittest.TestCase):
 
     def setUp(self):
-        Robot.reset()
-        self.robot = Robot.get_instance()
+        self.robot = Robot.reset()
         # self.robot.connect(port='/dev/tty.usbmodem1421')
         # self.robot.home()
 
@@ -238,3 +237,8 @@ class PipetteTest(unittest.TestCase):
             current_pos,
             {'x': 0, 'y': 0, 'z': 0, 'a': 0, 'b': 0.0}
         )
+
+    def test_delay(self):
+        self.p200.delay(1)
+
+        self.assertEquals(self.robot._commands[0].description, "Delaying 1 seconds")

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -242,3 +242,10 @@ class PipetteTest(unittest.TestCase):
         self.p200.delay(1)
 
         self.assertEquals(self.robot._commands[0].description, "Delaying 1 seconds")
+
+    def test_set_speed(self):
+        self.assertEquals(self.speed, 300)
+
+        self.p200.set_speed(100)
+
+        self.assertEquals(self.speed, 100)

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -241,11 +241,25 @@ class PipetteTest(unittest.TestCase):
     def test_delay(self):
         self.p200.delay(1)
 
-        self.assertEquals(self.robot._commands[0].description, "Delaying 1 seconds")
+        self.assertEquals(self.robot._commands[-1].description, "Delaying 1 seconds")
 
     def test_set_speed(self):
-        self.assertEquals(self.speed, 300)
+        self.assertEquals(self.p200.speed, 300)
 
         self.p200.set_speed(100)
 
-        self.assertEquals(self.speed, 100)
+        self.assertEquals(self.p200.speed, 100)
+
+    def test_pause_and_resume(self):
+        self.p200.aspirate(100)
+        self.p200.pause()
+        self.p200.dispense()
+        self.assertEquals(len(self.robot._commands), 4)
+
+        self.robot.run()
+
+        self.assertEquals(self.robot._commands[0].description, "Dispensing 100uL at None")
+        self.assertEquals(len(self.robot._commands), 1)
+
+        self.p200.resume()
+        self.assertEquals(len(self.robot._commands), 0)

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -251,17 +251,3 @@ class PipetteTest(unittest.TestCase):
         self.p200.set_speed(100)
 
         self.assertEquals(self.p200.speed, 100)
-
-    def test_pause_and_resume(self):
-        self.p200.aspirate(100)
-        self.p200.pause()
-        self.p200.dispense()
-        self.assertEquals(len(self.robot._commands), 4)
-
-        self.robot.run()
-
-        self.assertEquals(self.robot._commands[0].description, "Dispensing 100uL at None")
-        self.assertEquals(len(self.robot._commands), 1)
-
-        self.p200.resume()
-        self.assertEquals(len(self.robot._commands), 0)

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -6,7 +6,6 @@ from opentrons_sdk.robot.robot import Robot
 from opentrons_sdk.containers.placeable import Deck
 
 class RobotTest(unittest.TestCase):
-
 	def setUp(self):
 		Robot.reset()
 		self.robot = Robot.get_instance()
@@ -15,10 +14,16 @@ class RobotTest(unittest.TestCase):
 		self.robot._driver = mock.Mock()
 
 	def test_robot_move_to(self):
-
 		self.robot.move_to((Deck(), (100,0,0)))
 		self.robot.run()
-		print(self.robot._driver.mock_calls)
 		expected = [ call.move(z=10), call.move(x=100, y=0), call.move(z=0), call.wait_for_arrival() ]
 		self.assertEquals(self.robot._driver.mock_calls, expected)
-		
+
+	def test_robot_pause_and_resume(self):
+		self.robot.move_to((Deck(), (100,0,0)))
+		self.robot.pause()
+		self.robot.move_to((Deck(), (101,0,0)))
+		self.robot.run()
+		self.assertEquals(len(self.robot._commands), 1)
+		self.robot.resume()
+		self.assertEquals(len(self.robot._commands), 0)

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -24,6 +24,6 @@ class RobotTest(unittest.TestCase):
 		self.robot.pause()
 		self.robot.move_to((Deck(), (101,0,0)))
 		self.robot.run()
-		self.assertEquals(len(self.robot._commands), 1)
+		self.assertEquals(len(self.robot._commands), 2)
 		self.robot.resume()
 		self.assertEquals(len(self.robot._commands), 0)


### PR DESCRIPTION
This PR (by Katie and I):

* Adds a delay method on pipette that just waits
* Adds a set_speed method and a speed method that set and get the plunger speed (defaults to 300))
* Adds a pause and resume method - pause just halts the run method, queue resumes it
* Adds small unit tests for all of these methods

These were all tested on a robot in real life by us (in addition to unit tested).

Edit - I changed pause to jump to the beginning of the queue and edited the speed command in the driver so that it could change A, B, or XYZ speed (but not singular X/Y/Z speeds - this is not a 1.2 feature and I don't see support for it in the Smoothie docs)