### PR TITLE
optional user-friendly name for containers/instruments

### DIFF
--- a/opentrons_sdk/containers/__init__.py
+++ b/opentrons_sdk/containers/__init__.py
@@ -1,6 +1,8 @@
 from opentrons_sdk.robot.robot import Robot
 
 
-def load(container_name, slot):
+def load(container_name, slot, label=None):
+    if not label:
+        label = container_name
     protocol = Robot.get_instance()
-    return protocol.add_container(slot, container_name)
+    return protocol.add_container(slot, container_name, label)

--- a/opentrons_sdk/containers/placeable.py
+++ b/opentrons_sdk/containers/placeable.py
@@ -128,7 +128,9 @@ class Placeable(object):
         if child in self.children:
             return self.children[child]['coordinates']
 
-    def add(self, child, name, coordinates):
+    def add(self, child, name=None, coordinates=(0, 0, 0)):
+        if not name:
+            name = str(child)
         if name in self.children:
             raise Exception('Child with the name {} already exists'
                             .format(name))
@@ -247,8 +249,8 @@ class Deck(Placeable):
 
 
 class Slot(Placeable):
-    def add(self, child, name='slot', coordinates=(0, 0, 0)):
-        super().add(child, name, coordinates)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class Container(Placeable):

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -270,7 +270,3 @@ class Pipette(object):
 
         description = "Setting speed to {}mm/second".format(rate)
         self.robot.add_command(Command(do=_do, description=description))
-
-    @property
-    def name(self):
-        return self.size.lower()

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -8,6 +8,7 @@ class Pipette(object):
     def __init__(
             self,
             axis,
+            name=None,
             channels=1,
             min_volume=0,
             trash_container=None,
@@ -22,6 +23,10 @@ class Pipette(object):
 
         self.axis = axis
         self.channels = channels
+
+        if not name:
+            name = axis
+        self.name = name
 
         self.min_volume = min_volume
         self.max_volume = min_volume + 1
@@ -245,7 +250,3 @@ class Pipette(object):
 
     def supports_volume(self, volume):
         return self.max_volume <= volume <= self.max_volume
-
-    @property
-    def name(self):
-        return self.size.lower()

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -207,13 +207,24 @@ class Robot(object):
     def deck(self):
         return self._deck
 
-    def get_instruments(self):
+    def get_instruments_by_name(self, name):
+        res = []
+        for k, v in self.get_instruments():
+            if v.name == name:
+                res.append((k, v))
+
+        return res
+
+    def get_instruments(self, name=None):
         """
         :returns: sorted list of (axis, instrument)
         """
+        if name:
+            return self.get_instruments_by_name(name)
+
         return sorted(self._instruments.items())
 
-    def add_container(self, slot, container_name):
+    def add_container(self, slot, container_name, label):
         container = legacy_containers.get_legacy_container(container_name)
-        self._deck[slot].add(container, container_name)
+        self._deck[slot].add(container, label)
         return container

--- a/tests/opentrons_sdk/integration/test_protocol.py
+++ b/tests/opentrons_sdk/integration/test_protocol.py
@@ -12,20 +12,24 @@ class ProtocolTestCase(unittest.TestCase):
         self.robot = Robot.get_instance()
 
     def test_protocol_container_setup(self):
-        plate = containers.load('96-flat', 'A1')
+        plate = containers.load('96-flat', 'A1', 'myPlate')
         tiprack = containers.load('tiprack-10ul', 'B2')
 
         containers_list = self.robot.containers()
         self.assertEqual(len(containers_list), 2)
 
+        self.assertEquals(self.robot._deck['A1']['myPlate'], plate)
+        self.assertEquals(self.robot._deck['B2']['tiprack-10ul'], tiprack)
+
         self.assertTrue(plate in containers_list)
         self.assertTrue(tiprack in containers_list)
 
     def test_protocol_head(self):
-        trash = containers.load('point', 'A1')
+        trash = containers.load('point', 'A1', 'myTrash')
         tiprack = containers.load('tiprack-10ul', 'B2')
 
         p200 = instruments.Pipette(
+            name='myPipette',
             trash_container=trash,
             tip_racks=[tiprack],
             min_volume=10,  # These are variable
@@ -36,10 +40,13 @@ class ProtocolTestCase(unittest.TestCase):
         instruments_list = self.robot.get_instruments()
         self.assertEqual(instruments_list[0], ('B', p200))
 
+        instruments_list = self.robot.get_instruments('myPipette')
+        self.assertEqual(instruments_list[0], ('B', p200))
+
     def test_deck_setup(self):
         deck = self.robot.deck
 
-        trash = containers.load('point', 'A1')
+        trash = containers.load('point', 'A1', 'myTrash')
         tiprack = containers.load('tiprack-10ul', 'B2')
 
         self.assertTrue(isinstance(tiprack, Container))

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -31,6 +31,18 @@ class PipetteTest(unittest.TestCase):
         self.p200.calibrate_plunger(top=0, bottom=10, blow_out=12, drop_tip=13)
         self.p200.set_max_volume(200)
 
+    def test_get_instruments_by_name(self):
+        self.p1000 = instruments.Pipette(
+            trash_container=self.trash,
+            tip_racks=[self.tiprack],
+            min_volume=10,  # These are variable
+            axis="a",
+            name="p1000",
+            channels=1
+        )
+        result = list(self.robot.get_instruments('p1000'))
+        self.assertListEqual(result, [('A', self.p1000)])
+
     def test_placeables_reference(self):
 
         self.p200.aspirate(100, self.plate[0])


### PR DESCRIPTION
This PR adds optional user-defined names to containers and instruments, which can be queried by name through `robot`