### PR TITLE
117 s robot to deck and deck to robot coordinate conversion

### DIFF
--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -98,7 +98,7 @@ class CNCDriver(object):
     serial_timeout = 0.1
 
     # TODO: move to config
-    ot_version = None
+    ot_version = 'hood'
     ot_one_dimensions = {
         'hood':{
             'x': 300,
@@ -116,6 +116,9 @@ class CNCDriver(object):
             'z': 120
         }
     }
+
+    def get_dimensions(self):
+        return self.ot_one_dimensions[self.ot_version]
 
     def list_serial_ports(self):
         """ Lists serial port names
@@ -299,8 +302,6 @@ class CNCDriver(object):
         return res == b'ok'
 
     def invert_axis(self, axis, value, absolute=True):
-        if not self.ot_version:
-            self.ot_version = 'hood'
         if absolute:
             return self.ot_one_dimensions[self.ot_version][axis] - value
         else:

--- a/opentrons_sdk/helpers/helpers.py
+++ b/opentrons_sdk/helpers/helpers.py
@@ -1,0 +1,15 @@
+
+
+def unpack_coordinates(coordinates):
+    if not isinstance(coordinates, tuple):
+        coordinates = tuple([coordinates[axis] for axis in 'xyz'])
+
+    return coordinates
+
+
+def flip_coordinates(coordinates, dimensions):
+    coordinates = unpack_coordinates(coordinates)
+    x, y, z = coordinates
+    x_size, y_size, z_size = unpack_coordinates(dimensions)
+
+    return (x, y_size - y, z_size - z)

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -8,6 +8,8 @@ from opentrons_sdk.util import log
 from opentrons_sdk.containers.placeable import unpack_location
 from opentrons_sdk.containers.calibrator import apply_calibration
 
+from opentrons_sdk.helpers import helpers
+
 
 class Robot(object):
     _commands = None  # []
@@ -64,6 +66,10 @@ class Robot(object):
                 return robot_self._driver.wait_for_arrival()
 
         return InstrumentMotor()
+
+    def flip_coordinates(self, coordinates):
+        dimensions = self._driver.get_dimensions()
+        return helpers.flip_coordinates(coordinates, dimensions)
 
     def list_serial_ports(self):
         return self._driver.list_serial_ports()

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -198,8 +198,8 @@ class Robot(object):
         robot_rows = self.get_max_robot_rows()
         row_offset, col_offset, x_offset, y_offset = self.get_slot_offsets()
 
-        for col_index, col in enumerate('EDCBA'):
-            for row_index, row in enumerate(range(robot_rows, 0, -1)):
+        for col_index, col in enumerate('ABCDE'):
+            for row_index, row in enumerate(range(1, robot_rows + 1)):
                 slot = placeable.Slot()
                 slot_coordinates = (
                     (row_offset * row_index) + x_offset,

--- a/tests/opentrons_sdk/drivers/motor_test.py
+++ b/tests/opentrons_sdk/drivers/motor_test.py
@@ -47,6 +47,8 @@ class OpenTronsTest(SerialTestCase):
 
         self.motor = CNCDriver()
 
+        self.motor.ot_version = 'hood'
+
         self.smoothie_connected = False
 
         myport = ''

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -61,7 +61,7 @@ class PipetteTest(unittest.TestCase):
             (self.plate[0], self.plate[0].from_center(x=0, y=0, z=1)))
 
     def test_calibrate_placeable(self):
-        x, y, z = (161.0, 416.7, 3.0)
+        x, y, z = (161.0, 31.7, 3.0)
         well = self.plate[0]
         pos = well.from_center(x=0, y=0, z=-1, reference=self.plate)
         location = (self.plate, pos)


### PR DESCRIPTION
This PR adds a `flip_coordinates` method, to help us for loading 1.2 app calibration data. This flipping is based upon the `ot_version` dimensions specified in drivers/motor.py.

See the [python_protocols helpers methods](https://github.com/OpenTrons/python_protocols/blob/master/helpers/calibration.py) to see it's implementation