### PR TITLE
Transfer consolidate distribute

### DIFF
--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -107,13 +107,13 @@ class Pipette(object):
         return self
 
     def transfer(self, source, destination, volume=None):
-        volume = volume or current_volume
+        volume = volume or self.max_volume
         self.aspirate(volume, source)
         self.dispense(volume, destination)
         return self
 
     def distribute(self, source, destinations, volume=None, extra_pull=0):
-        volume = volume or current_volume
+        volume = volume or self.max_volume
         fractional_volume = volume / len(destinations)
 
         self.aspirate(volume + extra_pull, source)
@@ -123,7 +123,7 @@ class Pipette(object):
         return self
 
     def consolidate(self, destination, sources, volume=None):
-        volume = volume or current_volume
+        volume = volume or self.max_volume
         fractional_volume = (volume) / len(sources)
 
         for well in sources:

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -142,18 +142,6 @@ class Pipette(object):
         self.robot.add_command(Command(do=_do, description=description))
         return self
 
-    def touch_tip(self, radians=math.pi/4):
-        def _do():
-            num_aspirates = (2 * math.pi) / (radians)
-            for i in num_aspirates:
-                dispense(current_volume / num_aspirates).from_polar(0.9, math.pi / num_aspirates, 1)
-            self.motor.wait_for_arrival()
-
-        description = "Touch_tip with intervals of {}".format(str(radians))
-        self.robot.add_command(Command(do=_do, description=description))
-        self.current_volume = 0
-        return self
-
     def blow_out(self, location=None):
         if location:
             self.robot.move_to(location, self)

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -127,7 +127,6 @@ class Pipette(object):
         fractional_volume = (volume + extra_pull) / len(sources)
 
         for well in sources:
-            print(fractional_volume, well)
             self.aspirate(fractional_volume, well)
 
         self.dispense(volume, destination)

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -122,9 +122,9 @@ class Pipette(object):
 
         return self
 
-    def consolidate(self, destination, sources, volume=None, extra_pull=0):
+    def consolidate(self, destination, sources, volume=None):
         volume = volume or current_volume
-        fractional_volume = (volume + extra_pull) / len(sources)
+        fractional_volume = (volume) / len(sources)
 
         for well in sources:
             self.aspirate(fractional_volume, well)
@@ -133,8 +133,8 @@ class Pipette(object):
         return self
 
     def mix(self, repetitions=3):
+        volume = self.current_volume
         def _do():
-            volume = self.current_volume
             for i in range(repetitions):
                 self.dispense(volume)
                 self.aspirate(volume)

--- a/sample_protocol.py
+++ b/sample_protocol.py
@@ -1,0 +1,42 @@
+from opentrons_sdk import containers
+from opentrons_sdk.labware import instruments
+from opentrons_sdk.robot import Robot
+from opentrons_sdk.drivers.motor import CNCDriver
+import math, time
+import pdb;
+
+robot = Robot.get_instance()
+
+robot._driver = CNCDriver()
+
+plate = containers.load('96-flat', 'A2')
+trash = containers.load('point', 'A3')
+tiprack = containers.load('tiprack-10ul', 'B2')
+
+p200 = instruments.Pipette(
+    trash_container=trash,
+    tip_racks=[tiprack],
+    min_volume=0.1,  # These are variable
+    axis="b",
+    channels=1
+)
+
+robot.connect('/dev/tty.usbmodem1421')
+
+# robot.home()
+robot.move_head(x=144, y=269.5)
+robot.move_head(z=-50)
+
+p200.calibrate_position((plate, plate[0].center(plate)))
+p200.calibrate_plunger(top=0, bottom=15, blow_out=18, drop_tip=20)
+p200.set_max_volume(200)
+
+# p200.aspirate(200, plate[0])
+# p200.dispense(200, plate[4])
+#
+# p200.transfer(plate[0], plate[4], 200)
+p200.aspirate(100).mix()
+# p200.mix(3, 1)
+# p200.consolidate(plate[0], [plate[1], plate[2], plate[3]], 100, 9)
+
+robot.run()

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 from opentrons_sdk import containers
 
 from opentrons_sdk.labware import instruments
@@ -251,3 +252,21 @@ class PipetteTest(unittest.TestCase):
         self.p200.set_speed(100)
 
         self.assertEquals(self.p200.speed, 100)
+
+    def test_transfer_no_volume(self):
+        self.p200.aspirate = mock.Mock()
+        self.p200.dispense = mock.Mock()
+        self.p200.transfer(self.plate[0], self.plate[1])
+        self.robot.run()
+
+        self.assertTrue(self.p200.aspirate.calls, [mock.call.aspirate(self.p200.max_volume, self.plate[0])])
+        self.assertTrue(self.p200.dispense.calls, [mock.call.dispense(self.p200.current_volume, self.plate[1])])
+
+    def test_transfer_with_volume(self):
+        self.p200.aspirate = mock.Mock()
+        self.p200.dispense = mock.Mock()
+        self.p200.transfer(self.plate[0], self.plate[1], 100)
+        self.robot.run()
+
+        self.assertTrue(self.p200.aspirate.calls, [mock.call.aspirate(100, self.plate[0])])
+        self.assertTrue(self.p200.dispense.calls, [mock.call.dispense(100, self.plate[1])])

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -305,3 +305,25 @@ class PipetteTest(unittest.TestCase):
                         mock.call.dispense(fractional_volume, self.plate[3])]
                         )
         self.assertEqual(self.p200.aspirate.mock_calls, [mock.call.aspirate(volume, self.plate[0])])
+
+    def test_mix(self):
+        well = self.plate[0]
+        # It is necessary to aspirate before it is mocked out so that you have liquid
+        self.p200.current_volume = 100
+        self.p200.aspirate = mock.Mock()
+        self.p200.dispense = mock.Mock()
+        self.p200.mix()
+        self.robot.run()
+
+        print("****", len(self.p200.dispense.mock_calls))
+        print("****", self.p200.dispense.mock_calls)
+        self.assertEqual(self.p200.dispense.mock_calls,
+                        [mock.call.dispense(100),
+                        mock.call.dispense(100),
+                        mock.call.dispense(100)]
+                        )
+        self.assertEqual(self.p200.aspirate.mock_calls,
+                        [mock.call.aspirate(100),
+                        mock.call.aspirate(100),
+                        mock.call.aspirate(100)]
+                        )


### PR DESCRIPTION
This PR adds:

Transfer - just an aspirate then a dispense (defaults to max vol, like aspirate and dispense)
Distribute - an aspirate (with an extra pull_volume), then a series of dispense to an array of wells, who each get (volume / length of wells)ul.
Consolidate - opposite of distribute, but with no extra_pull.
Mix - by default just dispenses and then aspirates current_volume 3 times. can be given a different number of repetitions.

These all have unit tests and have been tested on the robot.