### PR TITLE
20161007 201600 fix mix and print command queing

### DIFF
--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -68,7 +68,7 @@ class Pipette(object):
                 .format(self.current_volume + volume)
             )
 
-        self.position_for_aspirate(volume, location)
+        self.position_for_aspirate(location)
 
         distance = self.plunge_distance(volume) * -1
 
@@ -111,7 +111,7 @@ class Pipette(object):
 
         return self
 
-    def position_for_aspirate(self, volume, location=None):
+    def position_for_aspirate(self, location=None):
         if location:
             self.robot.move_to_top(location, instrument=self)
 
@@ -119,7 +119,7 @@ class Pipette(object):
             def _prep_plunger():
                 self.plunger.move(self.positions['bottom'])
 
-            description = "Preparing to aspirate {0}uL".format(volume)
+            description = "Resetting plunger to bottom"
             self.robot.add_command(
                 Command(do=_prep_plunger, description=description))
 

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -163,15 +163,19 @@ class Pipette(object):
         volume = self.current_volume
 
         def _do():
-            for i in range(repetitions):
-                self.dispense(volume)
-                self.aspirate(volume)
-            self.plunger.wait_for_arrival()
+            # plunger movements are handled w/ aspirate/dispense
+            # using Command for printing description
+            pass
 
         description = "Mixing {0} times with a volume of {1}mm".format(
             repetitions, str(self.current_volume)
         )
         self.robot.add_command(Command(do=_do, description=description))
+
+        for i in range(repetitions):
+            self.dispense()
+            self.aspirate(volume)
+
         return self
 
     def blow_out(self, location=None):

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -57,7 +57,9 @@ class Pipette(object):
 
     def aspirate(self, volume=None, location=None):
 
-        if not volume:
+        if not isinstance(volume, (int, float, complex)):
+            if volume and not location:
+                location = volume
             volume = self.max_volume - self.current_volume
 
         if self.current_volume + volume > self.max_volume:
@@ -106,14 +108,16 @@ class Pipette(object):
 
     def dispense(self, volume=None, location=None):
 
-        if not volume:
-            volume = self.max_volume - self.current_volume
+        if not isinstance(volume, (int, float, complex)):
+            if volume and not location:
+                location = volume
+            volume = self.current_volume
 
         if self.current_volume - volume < 0:
             raise RuntimeWarning(
-                'Pipette cannot dispense {}ul'.
-                format(self.current_volume - volume)
-            )
+                'Pipette cannot dispense {}ul from {}ul'.
+                format(self.current_volume - volume,
+                       self.current_volume))
 
         if location:
             if isinstance(location, Placeable):

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -91,6 +91,7 @@ class Pipette(object):
             volume = self.current_volume
 
         if self.current_volume - volume < 0:
+            # TODO: this should alert a Warning here, but not stop execution
             volume = self.current_volume
 
         if location:

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -91,10 +91,7 @@ class Pipette(object):
             volume = self.current_volume
 
         if self.current_volume - volume < 0:
-            raise RuntimeWarning(
-                'Pipette cannot dispense {}ul from {}ul'.
-                format(self.current_volume - volume,
-                       self.current_volume))
+            volume = self.current_volume
 
         if location:
             self.robot.move_to(location, instrument=self)

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -97,15 +97,17 @@ class Pipette(object):
         if location:
             self.robot.move_to(location, instrument=self)
 
-        distance = self.plunge_distance(volume)
+        if volume:
+            distance = self.plunge_distance(volume)
 
-        def _do():
-            self.plunger.move(distance, mode='relative')
-            self.plunger.wait_for_arrival()
+            def _do():
+                self.plunger.move(distance, mode='relative')
+                self.plunger.wait_for_arrival()
 
-        description = "Dispensing {0}uL at {1}".format(volume, str(location))
-        self.robot.add_command(Command(do=_do, description=description))
-        self.current_volume -= volume
+            description = "Dispensing {0}uL at {1}".format(
+                volume, str(location))
+            self.robot.add_command(Command(do=_do, description=description))
+            self.current_volume -= volume
 
         return self
 

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -101,6 +101,8 @@ class Robot(object):
             return False
 
     def add_command(self, command):
+        print("Enqueing:", command.description)
+        log.info("Enqueing:", command.description)
         self._commands.append(command)
 
     def prepend_command(self, command):

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -258,7 +258,7 @@ class PipetteTest(unittest.TestCase):
         )
 
     def test_invalid_dispense(self):
-        self.assertRaises(RuntimeWarning, self.p200.dispense, 1)
+        # self.assertRaises(RuntimeWarning, self.p200.dispense, 1)
         self.assertRaises(IndexError, self.p200.dispense, -1)
 
     def test_blow_out(self):

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -387,9 +387,9 @@ class PipetteTest(unittest.TestCase):
         self.assertEqual(
             self.p200.dispense.mock_calls,
             [
-                mock.call.dispense(100),
-                mock.call.dispense(100),
-                mock.call.dispense(100)
+                mock.call.dispense(),
+                mock.call.dispense(),
+                mock.call.dispense()
             ]
         )
         self.assertEqual(


### PR DESCRIPTION
This PR:

1. Changes `Pipette.mix()` to just call `.aspirate()` and `.dispense()` instead of queueing it's own Commands
2. `.aspirate()` and `.dispense()` can take just a Placeable as argument, and volume will default to the full tip volume
3. `.dispense()` will accept a volume larger than it's current volume, converting internally to it's current volume so as not to move outside the plunger's limit
