### PR TITLE
82 m break down movements into discrete intervals and pause resume the queue test for precision

### DIFF
--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -290,6 +290,7 @@ class CNCDriver(object):
             res = self.send_command(self.MOVE, **args)
             if not res == b'ok':
                 return False
+            # check for a PAUSE or HALT flag here
         return True
 
     def move_head(self, mode='absolute', **kwargs):
@@ -325,6 +326,7 @@ class CNCDriver(object):
             res = self.send_command(self.MOVE, **args)
             if not res == b'ok':
                 return False
+            # check for a PAUSE or HALT flag here
         return True
 
     def flip_coordinates(self, coordinates, mode='absolute'):

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -76,10 +76,6 @@ class CNCDriver(object):
         self.can_move = Event()
         self.resume()
         self.head_speed = 3000  # smoothie's default speed in mm/minute
-        self.plunger_speed = {
-            'a': 300,
-            'b': 300
-        }
         self.current_commands = []
 
     def get_connected_port(self):
@@ -478,17 +474,16 @@ class CNCDriver(object):
         return self.set_steps_per_mm(axis, current_steps_per_mm)
 
     def set_head_speed(self, rate):
-        speed_command = self.SET_SPEED
         self.head_speed = rate
-        res = self.send_command(speed_command + "F" + str(rate))
+        kwargs = {"F": rate}
+        res = self.send_command(self.SET_SPEED, **kwargs)
         return res == b'ok'
 
     def set_plunger_speed(self, rate, axis):
-        if axis not in self.plunger_speed:
+        if axis.lower() not in 'ab':
             raise ValueError('Axis {} not supported'.format(axis))
-        speed_command = self.SET_SPEED
-        self.plunger_speed[axis] = rate
-        res = self.send_command(speed_command + axis + str(rate))
+        kwargs = {axis.lower(): rate}
+        res = self.send_command(self.SET_SPEED, **kwargs)
         return res == b'ok'
 
     def get_ot_version(self):

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -339,6 +339,7 @@ class CNCDriver(object):
         tolerance = step * 0.5
         while self.can_move.wait():
             if self.stopped.is_set():
+                self.resume()
                 return (False, 'Stopped')
             try:
                 args = next(args_iter)

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -282,12 +282,12 @@ class CNCDriver(object):
                              'please use mode=(absolute|relative)')
 
         self.set_coordinate_system(mode)
-        current = self.get_head_position()
+        current = self.get_head_position()['target']
         log.debug('Motor Driver', 'Current Head Position: {}'.format(current))
         vector = {
             axis: kwargs.get(
                 axis,
-                0 if mode == 'relative' else current['target'][axis]
+                0 if mode == 'relative' else current[axis]
             )
             for axis in 'xyz'
         }

--- a/opentrons_sdk/helpers/helpers.py
+++ b/opentrons_sdk/helpers/helpers.py
@@ -1,5 +1,4 @@
 import json
-import math
 
 from opentrons_sdk.util.vector import Vector
 

--- a/opentrons_sdk/helpers/helpers.py
+++ b/opentrons_sdk/helpers/helpers.py
@@ -19,7 +19,7 @@ def flip_coordinates(coordinates, dimensions):
     return (x, y_size - y, z_size - z)
 
 
-def increment_between(p1, p2, increment=5, mode='absolute'):
+def break_down_travel(p1, p2, increment=5, mode='absolute'):
     """
     given two points p1 and p2, this returns a list of
     incremental positions or relative steps

--- a/opentrons_sdk/helpers/helpers.py
+++ b/opentrons_sdk/helpers/helpers.py
@@ -19,30 +19,36 @@ def flip_coordinates(coordinates, dimensions):
     return (x, y_size - y, z_size - z)
 
 
-def break_down_travel(p1, p2, increment=5, mode='absolute'):
+def break_down_travel(p1, p2=Vector(0, 0, 0), increment=5, mode='absolute'):
     """
     given two points p1 and p2, this returns a list of
     incremental positions or relative steps
     """
-    if mode is 'absolute':
-        distance = p2 - p1
-    else:
-        distance = Vector(p2)
 
-    travel = math.sqrt(
-        pow(distance[0], 2) + pow(distance[1], 2) + pow(distance[2], 2))
+    heading = p2 - p1
+    if mode == 'relative':
+        heading = p1
+    length = heading.length()
 
-    divider = max(int(travel / increment), 1)
-    step = distance / divider
+    length_steps = length / increment
+    length_remainder = length % increment
+
+    vector_step = Vector(0, 0, 0)
+    if length_steps > 0:
+        vector_step = heading / length_steps
+    vector_remainder = vector_step * (length_remainder / increment)
 
     res = []
     if mode is 'absolute':
-        for i in range(divider):
-            p1 = p1 + step
+        for i in range(int(length_steps)):
+            p1 = p1 + vector_step
             res.append(p1)
+        p1 = p1 + vector_remainder
+        res.append(p1)
     else:
-        for i in range(divider):
-            res.append(step)
+        for i in range(int(length_steps)):
+            res.append(vector_step)
+        res.append(vector_remainder)
     return res
 
 

--- a/opentrons_sdk/helpers/helpers.py
+++ b/opentrons_sdk/helpers/helpers.py
@@ -19,7 +19,7 @@ def flip_coordinates(coordinates, dimensions):
     return (x, y_size - y, z_size - z)
 
 
-def path_to_steps(p1, p2, increment=5, mode='absolute'):
+def increment_between(p1, p2, increment=5, mode='absolute'):
     """
     given two points p1 and p2, this returns a list of
     incremental positions or relative steps

--- a/opentrons_sdk/helpers/helpers.py
+++ b/opentrons_sdk/helpers/helpers.py
@@ -1,4 +1,7 @@
 import json
+import math
+
+from opentrons_sdk.util.vector import Vector
 
 
 def unpack_coordinates(coordinates):
@@ -14,6 +17,39 @@ def flip_coordinates(coordinates, dimensions):
     x_size, y_size, z_size = unpack_coordinates(dimensions)
 
     return (x, y_size - y, z_size - z)
+
+
+def path_to_steps(p1, p2, increment=5, mode='absolute'):
+    """
+    given two points p1 and p2, this returns a list of
+    incremental positions or relative steps
+    """
+    Point = Vector
+    if not isinstance(p1, Vector):
+        Point = float
+
+    distance = Point(p2)
+    if mode is 'absolute':
+        distance = p2 - p1
+
+    if isinstance(p1, Vector):
+        travel = math.sqrt(
+            pow(distance[0], 2) + pow(distance[1], 2) + pow(distance[2], 2))
+    else:
+        travel = distance
+
+    divider = max(int(travel / increment), 1)
+    step = Point(distance / divider)
+
+    res = []
+    if mode is 'absolute':
+        for i in range(divider):
+            p1 = p1 + step
+            res.append(Point(p1))
+    else:
+        for i in range(divider):
+            res.append(step)
+    return res
 
 
 def import_calibration_json(json_string, robot, calibrated_top=False):

--- a/opentrons_sdk/helpers/helpers.py
+++ b/opentrons_sdk/helpers/helpers.py
@@ -24,28 +24,22 @@ def break_down_travel(p1, p2, increment=5, mode='absolute'):
     given two points p1 and p2, this returns a list of
     incremental positions or relative steps
     """
-    Point = Vector
-    if not isinstance(p1, Vector):
-        Point = float
-
-    distance = Point(p2)
     if mode is 'absolute':
         distance = p2 - p1
-
-    if isinstance(p1, Vector):
-        travel = math.sqrt(
-            pow(distance[0], 2) + pow(distance[1], 2) + pow(distance[2], 2))
     else:
-        travel = distance
+        distance = Vector(p2)
+
+    travel = math.sqrt(
+        pow(distance[0], 2) + pow(distance[1], 2) + pow(distance[2], 2))
 
     divider = max(int(travel / increment), 1)
-    step = Point(distance / divider)
+    step = distance / divider
 
     res = []
     if mode is 'absolute':
         for i in range(divider):
             p1 = p1 + step
-            res.append(Point(p1))
+            res.append(p1)
     else:
         for i in range(divider):
             res.append(step)

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -334,9 +334,6 @@ class Pipette(object):
 
         return volume / self.max_volume
 
-    def supports_volume(self, volume):
-        return self.max_volume <= volume <= self.max_volume
-
     def delay(self, seconds):
         def _do():
             self.plunger.wait(seconds)

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -77,7 +77,6 @@ class Pipette(object):
 
         def _do_aspirate():
             self.plunger.move(destination)
-            self.plunger.wait_for_arrival()
 
         description = "Aspirating {0}uL at {1}".format(volume, str(location))
         self.robot.add_command(
@@ -106,7 +105,6 @@ class Pipette(object):
 
             def _do():
                 self.plunger.move(destination)
-                self.plunger.wait_for_arrival()
 
             description = "Dispensing {0}uL at {1}".format(
                 volume, str(location))
@@ -188,7 +186,6 @@ class Pipette(object):
 
         def _do():
             self.plunger.move(self.positions['blow_out'])
-            self.plunger.wait_for_arrival()
 
         description = "Blow_out at {}".format(str(location))
         self.robot.add_command(Command(do=_do, description=description))
@@ -242,7 +239,6 @@ class Pipette(object):
         def _do():
             self.plunger.move(self.positions['drop_tip'])
             self.plunger.home()
-            self.plunger.wait_for_arrival()
 
         description = "Drop_tip at {}".format(str(location))
         self.robot.add_command(Command(do=_do, description=description))

--- a/opentrons_sdk/robot/command.py
+++ b/opentrons_sdk/robot/command.py
@@ -13,7 +13,7 @@ class Macro(object):
         self.description = description
         self._commands = []
 
-    def add(self, command: Command):
+    def add(self, command):
         if not isinstance(command, Command):
             raise TypeError(
                 'Expected object of type Command. Got "{}"'

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -268,7 +268,6 @@ class Robot(object):
         self._commands = []
         self.can_pop_command.set()
         self._driver.stop()
-        self._driver.resume()
         print('Robot ready to enqueue and execute new commands')
 
     def pause(self):

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -1,5 +1,6 @@
 import copy
 import os
+from threading import Event
 
 from opentrons_sdk import containers
 from opentrons_sdk.drivers import motor as motor_drivers
@@ -16,6 +17,9 @@ class Robot(object):
     def __init__(self, driver_instance=None):
         self._commands = []
         self._handlers = []
+
+        self.can_pop_command = Event()
+        self.can_pop_command.set()
 
         self._deck = containers.Deck()
         self.setup_deck()
@@ -63,9 +67,6 @@ class Robot(object):
 
             def home(self):
                 return robot_self._driver.home(axis)
-
-            def wait_for_arrival(self):
-                return robot_self._driver.wait_for_arrival()
 
             def wait(self, seconds):
                 robot_self._driver.wait(seconds)
@@ -117,7 +118,6 @@ class Robot(object):
 
     def move_head(self, *args, **kwargs):
         self._driver.move_head(*args, **kwargs)
-        self._driver.wait_for_arrival()
 
     def move_to(self, location, instrument=None, create_path=True):
         placeable, coordinates = containers.unpack_location(location)
@@ -144,7 +144,6 @@ class Robot(object):
                     x=coordinates[0],
                     y=coordinates[1],
                     z=coordinates[2])
-            self._driver.wait_for_arrival()
 
         # description = "Moving head to {} {}".format(
         #     str(placeable),
@@ -166,10 +165,8 @@ class Robot(object):
         return copy.deepcopy(self._commands)
 
     def run(self):
-        while self._commands:
+        while self.can_pop_command.wait() and self._commands:
             command = self._commands.pop(0)
-            if command.description == "Pausing":
-                return
 
             if command.description:
                 print("Executing:", command.description)
@@ -269,20 +266,18 @@ class Robot(object):
 
     def clear(self):
         self._commands = []
+        self.can_pop_command.set()
+        self._driver.stop()
+        self._driver.resume()
         print('Robot ready to enqueue and execute new commands')
 
     def pause(self):
-        # This method is for API use only - in a user protocol,
-        # it will jump the queue, which is counterintuitive
-        # and not very useful.
-        def _do():
-            print("Paused")
-
-        description = "Pausing"
-        self.prepend_command(Command(do=_do, description=description))
+        self.can_pop_command.clear()
+        self._driver.pause()
 
     def resume(self):
-        self.run()
+        self.can_pop_command.set()
+        self._driver.resume()
 
     def get_serial_ports_list(self):
         ports = []

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -51,6 +51,7 @@ class Robot(object):
         robot_self = self
 
         class InstrumentMotor():
+
             def move(self, value, speed=None, mode='absolute'):
                 kwargs = {axis: value}
                 if speed:
@@ -101,8 +102,9 @@ class Robot(object):
             return False
 
     def add_command(self, command):
-        print("Enqueing:", command.description)
-        log.info("Enqueing:", command.description)
+        if command.description:
+            print("Enqueing:", command.description)
+            log.info("Enqueing:", command.description)
         self._commands.append(command)
 
     def prepend_command(self, command):
@@ -144,10 +146,10 @@ class Robot(object):
                     z=coordinates[2])
             self._driver.wait_for_arrival()
 
-        description = "Moving head to {} {}".format(
-            str(placeable),
-            coordinates)
-        self.add_command(Command(do=_do, description=description))
+        # description = "Moving head to {} {}".format(
+        #     str(placeable),
+        #     coordinates)
+        self.add_command(Command(do=_do))
 
     def move_to_top(self, location, instrument=None, create_path=True):
         placeable, coordinates = containers.unpack_location(location)
@@ -169,8 +171,9 @@ class Robot(object):
             if command.description == "Pausing":
                 return
 
-            print("Executing:", command.description)
-            log.info("Executing:", command.description)
+            if command.description:
+                print("Executing:", command.description)
+                log.info("Executing:", command.description)
             try:
                 command.do()
             except KeyboardInterrupt as e:

--- a/opentrons_sdk/util/vector.py
+++ b/opentrons_sdk/util/vector.py
@@ -1,3 +1,5 @@
+import math
+
 from collections import namedtuple
 
 
@@ -40,6 +42,13 @@ class Vector(object):
 
     def is_iterable(self, arg):
         return hasattr(arg, "__iter__") or hasattr(arg, "__getitem__")
+
+    def length(self):
+        return math.sqrt(
+            pow(self.coordinates.x, 2) +
+            pow(self.coordinates.y, 2) +
+            pow(self.coordinates.z, 2)
+        )
 
     def __init__(self, *args, **kwargs):
         # self.coordinates = self.zero_coordinates()

--- a/opentrons_sdk/util/vector.py
+++ b/opentrons_sdk/util/vector.py
@@ -1,43 +1,9 @@
 from collections import namedtuple
-import math
 
 
 # To keep Python 3.4 compatibility
 def isclose(a, b, rel_tol):
     return abs(a - b) < rel_tol
-
-
-def path_to_steps(p1, p2, increment=5, mode='absolute'):
-    """
-    given two points p1 and p2, this returns a list of
-    incremental positions or relative steps
-    """
-    Point = Vector
-    if not isinstance(p1, Vector):
-        Point = float
-
-    distance = Point(p2)
-    if mode is 'absolute':
-        distance = p2 - p1
-
-    if isinstance(p1, Vector):
-        travel = math.sqrt(
-            pow(distance[0], 2) + pow(distance[1], 2) + pow(distance[2], 2))
-    else:
-        travel = distance
-
-    divider = max(int(travel / increment), 1)
-    step = Point(distance / divider)
-
-    res = []
-    if mode is 'absolute':
-        for i in range(divider):
-            p1 = p1 + step
-            res.append(Point(p1))
-    else:
-        for i in range(divider):
-            res.append(step)
-    return res
 
 
 class Vector(object):

--- a/opentrons_sdk/util/vector.py
+++ b/opentrons_sdk/util/vector.py
@@ -1,9 +1,43 @@
 from collections import namedtuple
+import math
 
 
 # To keep Python 3.4 compatibility
 def isclose(a, b, rel_tol):
     return abs(a - b) < rel_tol
+
+
+def path_to_steps(p1, p2, increment=5, mode='absolute'):
+    """
+    given two points p1 and p2, this returns a list of
+    incremental positions or relative steps
+    """
+    Point = Vector
+    if not isinstance(p1, Vector):
+        Point = float
+
+    distance = Point(p2)
+    if mode is 'absolute':
+        distance = p2 - p1
+
+    if isinstance(p1, Vector):
+        travel = math.sqrt(
+            pow(distance[0], 2) + pow(distance[1], 2) + pow(distance[2], 2))
+    else:
+        travel = distance
+
+    divider = max(int(travel / increment), 1)
+    step = Point(distance / divider)
+
+    res = []
+    if mode is 'absolute':
+        for i in range(divider):
+            p1 = p1 + step
+            res.append(Point(p1))
+    else:
+        for i in range(divider):
+            res.append(step)
+    return res
 
 
 class Vector(object):

--- a/tests/opentrons_sdk/drivers/test_motor.py
+++ b/tests/opentrons_sdk/drivers/test_motor.py
@@ -21,6 +21,15 @@ class OpenTronsTest(unittest.TestCase):
     def tearDown(self):
         self.motor.disconnect()
 
+    def test_set_plunger_speed(self):
+        res = self.motor.set_plunger_speed(400, 'a')
+        self.assertEquals(res, True)
+
+    def test_set_head_speed(self):
+        res = self.motor.set_head_speed(4000)
+        self.assertEquals(res, True)
+        self.assertEquals(self.motor.head_speed, 4000)
+
     def test_pause_resume(self):
         self.motor.home()
 

--- a/tests/opentrons_sdk/drivers/test_motor.py
+++ b/tests/opentrons_sdk/drivers/test_motor.py
@@ -30,7 +30,7 @@ class OpenTronsTest(unittest.TestCase):
         done.clear()
 
         def _move_head():
-            self.motor.move_head(x=100)
+            self.motor.move_head(x=100, y=0, z=0)
             done.set()
 
         thread = Thread(target=_move_head)
@@ -38,6 +38,13 @@ class OpenTronsTest(unittest.TestCase):
 
         self.motor.resume()
         done.wait()
+
+        coords = self.motor.get_head_position()
+        expected_coords = {
+            'target': (100, 0, 0),
+            'current': (100, 0, 0)
+        }
+        self.assertDictEqual(coords, expected_coords)
 
     def test_get_position(self):
         self.motor.home()

--- a/tests/opentrons_sdk/drivers/test_motor.py
+++ b/tests/opentrons_sdk/drivers/test_motor.py
@@ -1,4 +1,4 @@
-from threading import Thread
+from threading import (Thread, Event)
 import unittest
 
 from opentrons_sdk.drivers.motor import CNCDriver
@@ -24,20 +24,24 @@ class OpenTronsTest(unittest.TestCase):
     def test_pause_resume(self):
         self.motor.home()
 
-        self.motor.pause()
+        self.motor.resume()
+
+        done = Event()
+        done.clear()
 
         def _move_head():
             self.motor.move_head(x=100)
+            done.set()
 
         thread = Thread(target=_move_head)
         thread.start()
 
         self.motor.resume()
+        done.wait()
 
     def test_get_position(self):
         self.motor.home()
         self.motor.move_head(x=100)
-        self.motor.wait_for_arrival()
         coords = self.motor.get_head_position()
         expected_coords = {
             'target': (100, 250, 120),

--- a/tests/opentrons_sdk/drivers/test_motor.py
+++ b/tests/opentrons_sdk/drivers/test_motor.py
@@ -1,3 +1,4 @@
+from threading import Thread
 import unittest
 
 from opentrons_sdk.drivers.motor import CNCDriver
@@ -19,6 +20,19 @@ class OpenTronsTest(unittest.TestCase):
 
     def tearDown(self):
         self.motor.disconnect()
+
+    def test_pause_resume(self):
+        self.motor.home()
+
+        self.motor.pause()
+
+        def _move_head():
+            self.motor.move_head(x=100)
+
+        thread = Thread(target=_move_head)
+        thread.start()
+
+        self.motor.resume()
 
     def test_get_position(self):
         self.motor.home()

--- a/tests/opentrons_sdk/helpers/test_helpers.py
+++ b/tests/opentrons_sdk/helpers/test_helpers.py
@@ -1,42 +1,42 @@
 import unittest
 from opentrons_sdk.util.vector import Vector
-from opentrons_sdk.helpers.helpers import path_to_steps
+from opentrons_sdk.helpers.helpers import increment_between
 
 
 class HelpersTest(unittest.TestCase):
 
-    def test_path_to_steps(self):
+    def test_increment_between(self):
         # with 3-dimensional points
         p1 = Vector(0, 0, 0)
         p2 = Vector(10, -12, 14)
-        res = path_to_steps(
+        res = increment_between(
             p1, p2, increment=5, mode='absolute')
         self.assertEquals(res[-1], p2)
         self.assertEquals(len(res), 4)
 
         p1 = Vector(10, 12, 14)
         p2 = Vector(10, 12, 14)
-        res = path_to_steps(p1, p2, mode='relative')
+        res = increment_between(p1, p2, mode='relative')
         self.assertEquals(res[-1], Vector(2.5, 3.0, 3.5))
         self.assertEquals(len(res), 4)
 
         p1 = Vector(10, 12, 14)
         p2 = Vector(-10, -12, -14)
-        res = path_to_steps(p1, p2, mode='relative')
+        res = increment_between(p1, p2, mode='relative')
         self.assertEquals(res[-1], Vector(-2.5, -3.0, -3.5))
         self.assertEquals(len(res), 4)
 
         # with 1-dimensional points
         p1 = 0
         p2 = 21
-        res = path_to_steps(
+        res = increment_between(
             p1, p2, increment=3, mode='absolute')
         self.assertEquals(res[-1], p2)
         self.assertEquals(len(res), 7)
 
         p1 = 0
         p2 = 21
-        res = path_to_steps(
+        res = increment_between(
             p1, p2, increment=3, mode='relative')
         self.assertEquals(res[-1], 3)
         self.assertEquals(len(res), 7)

--- a/tests/opentrons_sdk/helpers/test_helpers.py
+++ b/tests/opentrons_sdk/helpers/test_helpers.py
@@ -1,0 +1,42 @@
+import unittest
+from opentrons_sdk.util.vector import Vector
+from opentrons_sdk.helpers.helpers import path_to_steps
+
+
+class HelpersTest(unittest.TestCase):
+
+    def test_path_to_steps(self):
+        # with 3-dimensional points
+        p1 = Vector(0, 0, 0)
+        p2 = Vector(10, -12, 14)
+        res = path_to_steps(
+            p1, p2, increment=5, mode='absolute')
+        self.assertEquals(res[-1], p2)
+        self.assertEquals(len(res), 4)
+
+        p1 = Vector(10, 12, 14)
+        p2 = Vector(10, 12, 14)
+        res = path_to_steps(p1, p2, mode='relative')
+        self.assertEquals(res[-1], Vector(2.5, 3.0, 3.5))
+        self.assertEquals(len(res), 4)
+
+        p1 = Vector(10, 12, 14)
+        p2 = Vector(-10, -12, -14)
+        res = path_to_steps(p1, p2, mode='relative')
+        self.assertEquals(res[-1], Vector(-2.5, -3.0, -3.5))
+        self.assertEquals(len(res), 4)
+
+        # with 1-dimensional points
+        p1 = 0
+        p2 = 21
+        res = path_to_steps(
+            p1, p2, increment=3, mode='absolute')
+        self.assertEquals(res[-1], p2)
+        self.assertEquals(len(res), 7)
+
+        p1 = 0
+        p2 = 21
+        res = path_to_steps(
+            p1, p2, increment=3, mode='relative')
+        self.assertEquals(res[-1], 3)
+        self.assertEquals(len(res), 7)

--- a/tests/opentrons_sdk/helpers/test_helpers.py
+++ b/tests/opentrons_sdk/helpers/test_helpers.py
@@ -25,18 +25,3 @@ class HelpersTest(unittest.TestCase):
         res = break_down_travel(p1, p2, mode='relative')
         self.assertEquals(res[-1], Vector(-2.5, -3.0, -3.5))
         self.assertEquals(len(res), 4)
-
-        # with 1-dimensional points
-        p1 = 0
-        p2 = 21
-        res = break_down_travel(
-            p1, p2, increment=3, mode='absolute')
-        self.assertEquals(res[-1], p2)
-        self.assertEquals(len(res), 7)
-
-        p1 = 0
-        p2 = 21
-        res = break_down_travel(
-            p1, p2, increment=3, mode='relative')
-        self.assertEquals(res[-1], 3)
-        self.assertEquals(len(res), 7)

--- a/tests/opentrons_sdk/helpers/test_helpers.py
+++ b/tests/opentrons_sdk/helpers/test_helpers.py
@@ -1,42 +1,42 @@
 import unittest
 from opentrons_sdk.util.vector import Vector
-from opentrons_sdk.helpers.helpers import increment_between
+from opentrons_sdk.helpers.helpers import break_down_travel
 
 
 class HelpersTest(unittest.TestCase):
 
-    def test_increment_between(self):
+    def test_break_down_travel(self):
         # with 3-dimensional points
         p1 = Vector(0, 0, 0)
         p2 = Vector(10, -12, 14)
-        res = increment_between(
+        res = break_down_travel(
             p1, p2, increment=5, mode='absolute')
         self.assertEquals(res[-1], p2)
         self.assertEquals(len(res), 4)
 
         p1 = Vector(10, 12, 14)
         p2 = Vector(10, 12, 14)
-        res = increment_between(p1, p2, mode='relative')
+        res = break_down_travel(p1, p2, mode='relative')
         self.assertEquals(res[-1], Vector(2.5, 3.0, 3.5))
         self.assertEquals(len(res), 4)
 
         p1 = Vector(10, 12, 14)
         p2 = Vector(-10, -12, -14)
-        res = increment_between(p1, p2, mode='relative')
+        res = break_down_travel(p1, p2, mode='relative')
         self.assertEquals(res[-1], Vector(-2.5, -3.0, -3.5))
         self.assertEquals(len(res), 4)
 
         # with 1-dimensional points
         p1 = 0
         p2 = 21
-        res = increment_between(
+        res = break_down_travel(
             p1, p2, increment=3, mode='absolute')
         self.assertEquals(res[-1], p2)
         self.assertEquals(len(res), 7)
 
         p1 = 0
         p2 = 21
-        res = increment_between(
+        res = break_down_travel(
             p1, p2, increment=3, mode='relative')
         self.assertEquals(res[-1], 3)
         self.assertEquals(len(res), 7)

--- a/tests/opentrons_sdk/helpers/test_helpers.py
+++ b/tests/opentrons_sdk/helpers/test_helpers.py
@@ -12,16 +12,13 @@ class HelpersTest(unittest.TestCase):
         res = break_down_travel(
             p1, p2, increment=5, mode='absolute')
         self.assertEquals(res[-1], p2)
-        self.assertEquals(len(res), 4)
+        self.assertEquals(len(res), 5)
 
-        p1 = Vector(10, 12, 14)
-        p2 = Vector(10, 12, 14)
-        res = break_down_travel(p1, p2, mode='relative')
-        self.assertEquals(res[-1], Vector(2.5, 3.0, 3.5))
-        self.assertEquals(len(res), 4)
-
-        p1 = Vector(10, 12, 14)
-        p2 = Vector(-10, -12, -14)
-        res = break_down_travel(p1, p2, mode='relative')
-        self.assertEquals(res[-1], Vector(-2.5, -3.0, -3.5))
-        self.assertEquals(len(res), 4)
+        p1 = Vector(10, -12, 14)
+        res = break_down_travel(p1, mode='relative')
+        expected = Vector(
+            0.46537410754407676,
+            -0.5584489290528921,
+            0.6515237505617075)
+        self.assertEquals(res[-1], expected)
+        self.assertEquals(len(res), 5)

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -231,7 +231,6 @@ class PipetteTest(unittest.TestCase):
 
     def test_invalid_aspirate(self):
         self.assertRaises(RuntimeWarning, self.p200.aspirate, 500)
-        self.assertRaises(IndexError, self.p200.aspirate, 1)
 
     def test_dispense(self):
         self.p200.aspirate(100)
@@ -256,10 +255,6 @@ class PipetteTest(unittest.TestCase):
             current_pos,
             {'a': 0, 'b': 10.0}
         )
-
-    def test_invalid_dispense(self):
-        # self.assertRaises(RuntimeWarning, self.p200.dispense, 1)
-        self.assertRaises(IndexError, self.p200.dispense, -1)
 
     def test_blow_out(self):
 

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -1,3 +1,4 @@
+import threading
 import unittest
 
 from opentrons_sdk.robot.robot import Robot
@@ -19,9 +20,39 @@ class RobotTest(unittest.TestCase):
 
     def test_robot_pause_and_resume(self):
         self.robot.move_to((Deck(), (100, 0, 0)))
-        self.robot.pause()
         self.robot.move_to((Deck(), (101, 0, 0)))
-        self.robot.run()
         self.assertEqual(len(self.robot._commands), 2)
+
+        self.robot.pause()
+
+        def _run():
+            self.robot.run()
+            self.assertEqual(len(self.robot._commands), 0)
+
+        thread = threading.Thread(target=_run)
+        thread.start()
         self.robot.resume()
+        thread.join(0.5)
+
+        self.assertEquals(thread.is_alive(), False)
         self.assertEqual(len(self.robot._commands), 0)
+
+        self.robot.clear()
+
+        self.robot.move_to((Deck(), (100, 0, 0)))
+        self.robot.move_to((Deck(), (101, 0, 0)))
+
+        def _run():
+            self.robot.run()
+            self.assertEqual(len(self.robot._commands), 0)
+
+        self.robot.pause()
+
+        thread = threading.Thread(target=_run)
+        thread.start()
+        thread.join(0.01)
+
+        self.assertEquals(thread.is_alive(), True)
+        self.assertEqual(len(self.robot._commands) > 0, True)
+
+        self.robot.resume()

--- a/tests/opentrons_sdk/util/test_vector.py
+++ b/tests/opentrons_sdk/util/test_vector.py
@@ -1,6 +1,6 @@
 import unittest
 
-from opentrons_sdk.util.vector import Vector, path_to_steps
+from opentrons_sdk.util.vector import Vector
 
 
 class VectorTestCase(unittest.TestCase):
@@ -57,37 +57,3 @@ class VectorTestCase(unittest.TestCase):
 
         res = v1 * Vector(-1.0, -1.0, -1.0)
         self.assertEqual(res, Vector(-2.0, -4.0, -6.0))
-
-    def test_path_to_steps(self):
-        p1 = Vector(0, 0, 0)
-        p2 = Vector(10, -12, 14)
-        res = path_to_steps(
-            p1, p2, increment=5, mode='absolute')
-        self.assertEquals(res[-1], p2)
-        self.assertEquals(len(res), 4)
-
-        p1 = Vector(10, 12, 14)
-        p2 = Vector(10, 12, 14)
-        res = path_to_steps(p1, p2, mode='relative')
-        self.assertEquals(res[-1], Vector(2.5, 3.0, 3.5))
-        self.assertEquals(len(res), 4)
-
-        p1 = Vector(10, 12, 14)
-        p2 = Vector(-10, -12, -14)
-        res = path_to_steps(p1, p2, mode='relative')
-        self.assertEquals(res[-1], Vector(-2.5, -3.0, -3.5))
-        self.assertEquals(len(res), 4)
-
-        p1 = 0
-        p2 = 21
-        res = path_to_steps(
-            p1, p2, increment=3, mode='absolute')
-        self.assertEquals(res[-1], p2)
-        self.assertEquals(len(res), 7)
-
-        p1 = 0
-        p2 = 21
-        res = path_to_steps(
-            p1, p2, increment=3, mode='relative')
-        self.assertEquals(res[-1], 3)
-        self.assertEquals(len(res), 7)

--- a/tests/opentrons_sdk/util/test_vector.py
+++ b/tests/opentrons_sdk/util/test_vector.py
@@ -1,6 +1,6 @@
 import unittest
 
-from opentrons_sdk.util.vector import Vector
+from opentrons_sdk.util.vector import Vector, path_to_steps
 
 
 class VectorTestCase(unittest.TestCase):
@@ -57,3 +57,37 @@ class VectorTestCase(unittest.TestCase):
 
         res = v1 * Vector(-1.0, -1.0, -1.0)
         self.assertEqual(res, Vector(-2.0, -4.0, -6.0))
+
+    def test_path_to_steps(self):
+        p1 = Vector(0, 0, 0)
+        p2 = Vector(10, -12, 14)
+        res = path_to_steps(
+            p1, p2, increment=5, mode='absolute')
+        self.assertEquals(res[-1], p2)
+        self.assertEquals(len(res), 4)
+
+        p1 = Vector(10, 12, 14)
+        p2 = Vector(10, 12, 14)
+        res = path_to_steps(p1, p2, mode='relative')
+        self.assertEquals(res[-1], Vector(2.5, 3.0, 3.5))
+        self.assertEquals(len(res), 4)
+
+        p1 = Vector(10, 12, 14)
+        p2 = Vector(-10, -12, -14)
+        res = path_to_steps(p1, p2, mode='relative')
+        self.assertEquals(res[-1], Vector(-2.5, -3.0, -3.5))
+        self.assertEquals(len(res), 4)
+
+        p1 = 0
+        p2 = 21
+        res = path_to_steps(
+            p1, p2, increment=3, mode='absolute')
+        self.assertEquals(res[-1], p2)
+        self.assertEquals(len(res), 7)
+
+        p1 = 0
+        p2 = 21
+        res = path_to_steps(
+            p1, p2, increment=3, mode='relative')
+        self.assertEquals(res[-1], 3)
+        self.assertEquals(len(res), 7)


### PR DESCRIPTION
This PR:

1. breaks down `motor.move_head()` commands into smaller steps so they can be paused
2. enqueues `motor.move_head()` commands, which can be paused, resumed, and stopped
3. refactored `robot.pause()`, `robot.resume()`, and `robot.clear()` handle the `motor`'s queue
4. removed "relative" movements from robot and instrument