### PR TITLE
update mix to take optional volume, fix old test and add args test

### DIFF
--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -158,8 +158,8 @@ class Pipette(object):
         self.dispense(volume, destination)
         return self
 
-    def mix(self, repetitions=3):
-        volume = self.current_volume
+    def mix(self, repetitions=3, volume=None):
+        volume = volume or self.current_volume
 
         def _do():
             # plunger movements are handled w/ aspirate/dispense
@@ -172,10 +172,10 @@ class Pipette(object):
         self.robot.add_command(Command(do=_do, description=description))
 
         for i in range(repetitions):
-            self.dispense()
+            self.dispense(volume)
             self.aspirate(volume)
 
-        self.dispense()
+        self.dispense(volume)
 
         return self
 

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -382,15 +382,13 @@ class PipetteTest(unittest.TestCase):
         self.p200.mix()
         self.robot.run()
 
-        print("****", len(self.p200.dispense.mock_calls))
-        print("****", self.p200.dispense.mock_calls)
         self.assertEqual(
             self.p200.dispense.mock_calls,
             [
-                mock.call.dispense(),
-                mock.call.dispense(),
-                mock.call.dispense(),
-                mock.call.dispense()
+                mock.call.dispense(100),
+                mock.call.dispense(100),
+                mock.call.dispense(100),
+                mock.call.dispense(100)
             ]
         )
         self.assertEqual(
@@ -401,3 +399,26 @@ class PipetteTest(unittest.TestCase):
                 mock.call.aspirate(100)
             ]
         )
+
+        def test_mix_with_args(self):
+            self.p200.current_volume = 100
+            self.p200.aspirate = mock.Mock()
+            self.p200.dispense = mock.Mock()
+            self.p200.mix(volume=50, repetitions=2)
+            self.robot.run()
+
+            self.assertEqual(
+                self.p200.dispense.mock_calls,
+                [
+                    mock.call.dispense(50),
+                    mock.call.dispense(50),
+                    mock.call.dispense(50)
+                ]
+            )
+            self.assertEqual(
+                self.p200.aspirate.mock_calls,
+                [
+                    mock.call.aspirate(50),
+                    mock.call.aspirate(50)
+                ]
+            )


### PR DESCRIPTION
This small PR addresses a feature request from the science team to be able to give a volume to the Mix command. A test was added for this (and for the previously untested repetitions arg).