### PR TITLE
20161013 161000 expand gcode support

### DIFF
--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -36,6 +36,9 @@ class CNCDriver(object):
     SET_SPEED = 'G0'
     HALT = 'M112'
     CALM_DOWN = 'M999'
+    ACCELERATION = 'M204'
+    MOTORS_ON = 'M17'
+    MOTORS_OFF = 'M18'
 
     DISENGAGE_FEEDBACK = 'M63'
 
@@ -539,3 +542,11 @@ class CNCDriver(object):
         else:
             raise IndexError(
                 "Smoothie mosfet not at index {}".format(mosfet_index))
+
+    def power_on(self):
+        res = self.send_command(self.MOTORS_ON)
+        return res == b'ok'
+
+    def power_off(self):
+        res = self.send_command(self.MOTORS_OFF)
+        return res == b'ok'

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -525,9 +525,8 @@ class CNCDriver(object):
             res = json.loads(first_line.decode())
             res = res.get(self.GET_ENDSTOPS)
             obj = {}
-            for key, value in res.items():
-                axis = key[-1]
-                obj[axis] = bool(value)
+            for axis in 'xyzab':
+                obj[axis] = bool(res.get('min_' + axis))
             return obj
         else:
             return False

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -58,8 +58,14 @@ class CNCDriver(object):
         'y': 'config-set sd beta_steps_per_mm '
     }
 
-    MOSFET_ON = ['M41', 'M43', 'M45', 'M47', 'M49', 'M51']
-    MOSFET_OFF = ['M40', 'M42', 'M44', 'M46', 'M48', 'M50']
+    MOSFET = [
+        {True: 'M41', False: 'M40'},
+        {True: 'M43', False: 'M42'},
+        {True: 'M45', False: 'M44'},
+        {True: 'M47', False: 'M46'},
+        {True: 'M49', False: 'M48'},
+        {True: 'M51', False: 'M50'}
+    ]
 
     """
     Serial port connection to talk to the device.
@@ -532,13 +538,11 @@ class CNCDriver(object):
             return False
 
     def set_mosfet(self, mosfet_index, state):
-        if mosfet_index < len(self.MOSFET_OFF):
-            command = self.MOSFET_OFF[mosfet_index]
-            if state:
-                command = self.MOSFET_ON[mosfet_index]
+        try:
+            command = self.MOSFET[mosfet_index][bool(state)]
             res = self.send_command(command)
             return res == b'ok'
-        else:
+        except IndexError:
             raise IndexError(
                 "Smoothie mosfet not at index {}".format(mosfet_index))
 

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -511,3 +511,17 @@ class CNCDriver(object):
         command += str(value)
         res = self.send_command(command)
         return res.decode().split(' ')[-1] == str(value)
+
+    def get_endstop_switches(self):
+        res = self.send_command(self.GET_ENDSTOPS)
+        ok_res = self.wait_for_response()
+        if ok_res == b'ok':
+            res = json.loads(res.decode())
+            res = res.get(self.GET_ENDSTOPS)
+            obj = {}
+            for key, value in res.items():
+                axis = key[-1]
+                obj[axis] = bool(value)
+            return obj
+        else:
+            return False

--- a/opentrons_sdk/drivers/virtual_smoothie.py
+++ b/opentrons_sdk/drivers/virtual_smoothie.py
@@ -180,6 +180,12 @@ class VirtualSmoothie(object):
     def process_mosfet_state(self, arguments):
         return 'ok'
 
+    def process_power_on(self, arguments):
+        return 'ok'
+
+    def process_power_off(self, arguments):
+        return 'ok'
+
     def insert_response(self, message):
         messages = message.split('\n')
         self.responses = list(reversed(messages)) + self.responses
@@ -212,6 +218,8 @@ class VirtualSmoothie(object):
             'M49': self.process_mosfet_state,
             'M50': self.process_mosfet_state,
             'M51': self.process_mosfet_state,
+            'M17': self.process_power_on,
+            'M18': self.process_power_off,
             'version': self.process_version,
             'config-get': self.process_config_get,
             'config-set': self.process_config_set

--- a/opentrons_sdk/drivers/virtual_smoothie.py
+++ b/opentrons_sdk/drivers/virtual_smoothie.py
@@ -177,6 +177,9 @@ class VirtualSmoothie(object):
     def process_disengage_feedback(self, arguments):
         return 'feedback disengaged\nok'
 
+    def process_mosfet_state(self, arguments):
+        return 'ok'
+
     def insert_response(self, message):
         messages = message.split('\n')
         self.responses = list(reversed(messages)) + self.responses
@@ -197,6 +200,18 @@ class VirtualSmoothie(object):
             'M63': self.process_disengage_feedback,
             'G90': self.process_absolute_positioning,
             'G91': self.process_relative_positioning,
+            'M40': self.process_mosfet_state,
+            'M41': self.process_mosfet_state,
+            'M42': self.process_mosfet_state,
+            'M43': self.process_mosfet_state,
+            'M44': self.process_mosfet_state,
+            'M45': self.process_mosfet_state,
+            'M46': self.process_mosfet_state,
+            'M47': self.process_mosfet_state,
+            'M48': self.process_mosfet_state,
+            'M49': self.process_mosfet_state,
+            'M50': self.process_mosfet_state,
+            'M51': self.process_mosfet_state,
             'version': self.process_version,
             'config-get': self.process_config_get,
             'config-set': self.process_config_set

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -291,3 +291,14 @@ class Robot(object):
 
     def get_connected_port(self):
         return self._driver.get_connected_port()
+
+    def mosfet(self, mosfet_index, state, now=False):
+        def _do():
+            self._driver.set_mosfet(mosfet_index, state)
+
+        if now:
+            return _do()
+        else:
+            description = 'Setting Smoothie mosfet #{} to {}'.format(
+                mosfet_index, state)
+            self.add_command(Command(do=_do, description=description))

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -292,6 +292,9 @@ class Robot(object):
     def get_connected_port(self):
         return self._driver.get_connected_port()
 
+    def switches(self):
+        return self._driver.get_endstop_switches()
+
     def mosfet(self, mosfet_index, state, now=False):
         def _do():
             self._driver.set_mosfet(mosfet_index, state)

--- a/tests/opentrons_sdk/drivers/test_motor.py
+++ b/tests/opentrons_sdk/drivers/test_motor.py
@@ -170,3 +170,10 @@ class OpenTronsTest(unittest.TestCase):
         self.assertTrue(res)
 
         self.assertRaises(IndexError, self.motor.set_mosfet, 6, True)
+
+    def test_power_on_off(self):
+        res = self.motor.power_on()
+        self.assertTrue(res)
+
+        res = self.motor.power_off()
+        self.assertTrue(res)

--- a/tests/opentrons_sdk/drivers/test_motor.py
+++ b/tests/opentrons_sdk/drivers/test_motor.py
@@ -136,3 +136,28 @@ class OpenTronsTest(unittest.TestCase):
 
         self.assertEqual(exptected_x, new_x_steps)
         self.assertEqual(exptected_y, new_y_steps)
+
+    def test_get_endstop_switches(self):
+        res = self.motor.get_endstop_switches()
+        expected = {
+            'x': False,
+            'y': False,
+            'z': False,
+            'a': False,
+            'b': False
+        }
+        self.assertEquals(res, expected)
+        try:
+            self.motor.move_head(x=-100)
+            self.motor.move_head(x=-101)
+        except Exception:
+            pass
+        res = self.motor.get_endstop_switches()
+        expected = {
+            'x': True,
+            'y': False,
+            'z': False,
+            'a': False,
+            'b': False
+        }
+        self.assertEquals(res, expected)

--- a/tests/opentrons_sdk/drivers/test_motor.py
+++ b/tests/opentrons_sdk/drivers/test_motor.py
@@ -21,9 +21,14 @@ class OpenTronsTest(unittest.TestCase):
     def tearDown(self):
         self.motor.disconnect()
 
+    def test_message_timeout(self):
+        self.assertRaises(RuntimeWarning, self.motor.wait_for_response)
+
     def test_set_plunger_speed(self):
         res = self.motor.set_plunger_speed(400, 'a')
         self.assertEquals(res, True)
+
+        self.assertRaises(ValueError, self.motor.set_plunger_speed, 400, 'x')
 
     def test_set_head_speed(self):
         res = self.motor.set_head_speed(4000)
@@ -136,6 +141,9 @@ class OpenTronsTest(unittest.TestCase):
 
         self.assertEqual(exptected_x, new_x_steps)
         self.assertEqual(exptected_y, new_y_steps)
+
+        self.assertRaises(ValueError, self.motor.get_steps_per_mm, 'z')
+        self.assertRaises(ValueError, self.motor.set_steps_per_mm, 'z', 80.0)
 
     def test_get_endstop_switches(self):
         res = self.motor.get_endstop_switches()

--- a/tests/opentrons_sdk/drivers/test_motor.py
+++ b/tests/opentrons_sdk/drivers/test_motor.py
@@ -161,3 +161,12 @@ class OpenTronsTest(unittest.TestCase):
             'b': False
         }
         self.assertEquals(res, expected)
+
+    def test_set_mosfet(self):
+        res = self.motor.set_mosfet(0, True)
+        self.assertTrue(res)
+
+        res = self.motor.set_mosfet(5, False)
+        self.assertTrue(res)
+
+        self.assertRaises(IndexError, self.motor.set_mosfet, 6, True)

--- a/tests/opentrons_sdk/drivers/test_virtual_smoothie.py
+++ b/tests/opentrons_sdk/drivers/test_virtual_smoothie.py
@@ -174,6 +174,21 @@ class VirtualSmoothieTestCase(unittest.TestCase):
         response = self.s.readline()
         self.assertEqual(response, b'{"limit":"min_x"}')
 
+    def test_mosfet_state(self):
+        for i in range(12):
+            self.s.write('M{}'.format(i + 40))
+            response = self.s.readline()
+            self.assertEqual(response, b'ok')
+
+    def test_power_on_off(self):
+        self.s.write('M17')
+        response = self.s.readline()
+        self.assertEqual(response, b'ok')
+
+        self.s.write('M18')
+        response = self.s.readline()
+        self.assertEqual(response, b'ok')
+
     def test_move(self):
 
         self.s.write('G90')

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -27,7 +27,6 @@ class RobotTest(unittest.TestCase):
 
         def _run():
             self.robot.run()
-            self.assertEqual(len(self.robot._commands), 0)
 
         thread = threading.Thread(target=_run)
         thread.start()
@@ -44,7 +43,6 @@ class RobotTest(unittest.TestCase):
 
         def _run():
             self.robot.run()
-            self.assertEqual(len(self.robot._commands), 0)
 
         self.robot.pause()
 

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -75,11 +75,7 @@ class RobotTest(unittest.TestCase):
             'b': False
         }
         self.assertEquals(res, expected)
-        try:
-            self.robot.move_head(x=-199)
-            self.robot.move_head(x=-199)
-        except Exception:
-            pass
+        self.assertRaises(RuntimeWarning, self.robot.move_head, x=-199)
         res = self.robot.switches()
         expected = {
             'x': True,

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -56,3 +56,11 @@ class RobotTest(unittest.TestCase):
         self.assertEqual(len(self.robot._commands) > 0, True)
 
         self.robot.resume()
+
+    def test_mosfet(self):
+        self.robot.mosfet(0, True)
+        self.assertEqual(len(self.robot._commands), 1)
+        self.robot.run()
+        self.assertEqual(len(self.robot._commands), 0)
+        self.robot.mosfet(0, True, now=True)
+        self.assertEqual(len(self.robot._commands), 0)

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -64,3 +64,28 @@ class RobotTest(unittest.TestCase):
         self.assertEqual(len(self.robot._commands), 0)
         self.robot.mosfet(0, True, now=True)
         self.assertEqual(len(self.robot._commands), 0)
+
+    def test_switches(self):
+        res = self.robot.switches()
+        expected = {
+            'x': False,
+            'y': False,
+            'z': False,
+            'a': False,
+            'b': False
+        }
+        self.assertEquals(res, expected)
+        try:
+            self.robot.move_head(x=-199)
+            self.robot.move_head(x=-199)
+        except Exception:
+            pass
+        res = self.robot.switches()
+        expected = {
+            'x': True,
+            'y': False,
+            'z': False,
+            'a': False,
+            'b': False
+        }
+        self.assertEquals(res, expected)


### PR DESCRIPTION
This PR adds some more gcode functionality to the motor driver:

1. Power on/off the motors so they don't over-heat
2. Get the current state of the homing switches (this is added to robot as well)
3. Set the state of the Smoothieboard's 6 Mosfets (for example controlling the magbead module)