### PR TITLE
119 m allow aspirate dispense to set speed

### DIFF
--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -60,7 +60,7 @@ class Pipette(object):
 
         return self
 
-    def aspirate(self, volume=None, location=None):
+    def aspirate(self, volume=None, location=None, rate=1.0):
 
         if not isinstance(volume, (int, float, complex)):
             if volume and not location:
@@ -79,8 +79,10 @@ class Pipette(object):
         distance = self.plunge_distance(self.current_volume)
         destination = self.positions['bottom'] - distance
 
+        speed = self.speeds['aspirate'] * rate
+
         def _do_aspirate():
-            self.plunger.speed(self.speeds['aspirate'])
+            self.plunger.speed(speed)
             self.plunger.move(destination)
 
         description = "Aspirating {0}uL at {1}".format(volume, str(location))
@@ -89,7 +91,7 @@ class Pipette(object):
 
         return self
 
-    def dispense(self, volume=None, location=None):
+    def dispense(self, volume=None, location=None, rate=1.0):
 
         if not isinstance(volume, (int, float, complex)):
             if volume and not location:
@@ -108,8 +110,10 @@ class Pipette(object):
             distance = self.plunge_distance(self.current_volume)
             destination = self.positions['bottom'] - distance
 
+            speed = self.speeds['dispense'] * rate
+
             def _do():
-                self.plunger.speed(self.speeds['dispense'])
+                self.plunger.speed(speed)
                 self.plunger.move(destination)
 
             description = "Dispensing {0}uL at {1}".format(
@@ -355,11 +359,9 @@ class Pipette(object):
         self.robot.add_command(Command(do=_do, description=description))
         return self
 
-    def set_speed(self, property, rate):
-        if property in self.speeds:
-            self.speeds[property] = rate
-        else:
-            raise KeyError(
-                "{} speed can not be set on the pipette".format(property))
+    def set_speed(self, **kwargs):
+        keys = {'head', 'aspirate', 'dispense'} & kwargs.keys()
+        for key in keys:
+            self.speeds[key] = kwargs.get(key)
 
         return self

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -79,7 +79,6 @@ class Pipette(object):
         def _do_aspirate():
             self.plunger.speed(self.speeds['aspirate'])
             self.plunger.move(distance, mode='relative')
-            self.plunger.wait_for_arrival()
 
         description = "Aspirating {0}uL at {1}".format(volume, str(location))
         self.robot.add_command(
@@ -108,7 +107,6 @@ class Pipette(object):
             def _do():
                 self.plunger.speed(self.speeds['dispense'])
                 self.plunger.move(distance, mode='relative')
-                self.plunger.wait_for_arrival()
 
             description = "Dispensing {0}uL at {1}".format(
                 volume, str(location))
@@ -191,7 +189,6 @@ class Pipette(object):
 
         def _do():
             self.plunger.move(self.positions['blow_out'])
-            self.plunger.wait_for_arrival()
 
         description = "Blow_out at {}".format(str(location))
         self.robot.add_command(Command(do=_do, description=description))
@@ -229,9 +226,6 @@ class Pipette(object):
                 self.robot.move_head(z=-tip_plunge, mode='relative')
                 self.robot.move_head(z=tip_plunge, mode='relative')
 
-            self.plunger.wait_for_arrival()
-            self.robot.home('z')
-
         description = "Picking up tip from {0}".format(str(location))
         self.robot.add_command(Command(do=_do, description=description))
         return self
@@ -243,7 +237,6 @@ class Pipette(object):
         def _do():
             self.plunger.move(self.positions['drop_tip'])
             self.plunger.home()
-            self.plunger.wait_for_arrival()
 
         description = "Drop_tip at {}".format(str(location))
         self.robot.add_command(Command(do=_do, description=description))

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -90,15 +90,22 @@ class Robot(object):
             port = self._driver.VIRTUAL_SMOOTHIE_PORT
         return self._driver.connect(port)
 
-    def home(self, *args):
-        if self._driver.calm_down():
-            if args:
-                return self._driver.home(*args)
+    def home(self, *args, **kwargs):
+        def _do():
+            if self._driver.calm_down():
+                if args:
+                    return self._driver.home(*args)
+                else:
+                    self._driver.home('z')
+                    return self._driver.home('x', 'y', 'b', 'a')
             else:
-                self._driver.home('z')
-                return self._driver.home('x', 'y', 'b', 'a')
+                return False
+
+        if kwargs.get('now'):
+            return _do()
         else:
-            return False
+            description = "Homing Robot"
+            self.add_command(Command(do=_do, description=description))
 
     def add_command(self, command):
         print("Enqueing:", command.description)

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -56,10 +56,8 @@ class Robot(object):
 
         class InstrumentMotor():
 
-            def move(self, value, speed=None, mode='absolute'):
+            def move(self, value, mode='absolute'):
                 kwargs = {axis: value}
-                if speed:
-                    self.speed(speed)
 
                 return robot_self._driver.move_plunger(
                     mode=mode, **kwargs

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -41,7 +41,9 @@ class PipetteTest(unittest.TestCase):
             min_volume=10,  # These are variable
             axis="a",
             name="p1000",
-            channels=1
+            channels=1,
+            aspirate_speed=300,
+            dispense_speed=500
         )
         result = list(self.robot.get_instruments('p1000'))
         self.assertListEqual(result, [('A', self.p1000)])
@@ -91,6 +93,18 @@ class PipetteTest(unittest.TestCase):
         self.assertDictEqual(
             self.p200.calibration_data,
             expected_calibration_data)
+
+    def test_aspirate_rate(self):
+        self.p200.set_speed(aspirate=300, dispense=500)
+        self.robot.clear()
+        self.p200.plunger.speed = mock.Mock()
+        self.p200.aspirate(100, rate=2.0).dispense(rate=.5)
+        self.robot.run()
+        expected = [
+            mock.call(600.0),
+            mock.call(250.0)
+        ]
+        self.assertEquals(self.p200.plunger.speed.mock_calls, expected)
 
     def test_aspirate_move_to(self):
         x, y, z = (161.0, 116.7, 3.0)
@@ -289,14 +303,11 @@ class PipetteTest(unittest.TestCase):
 
     def test_set_speed(self):
 
-        self.p200.set_speed('aspirate', 100)
+        self.p200.set_speed(aspirate=100)
         self.assertEqual(self.p200.speeds['aspirate'], 100)
 
-        self.p200.set_speed('dispense', 100)
+        self.p200.set_speed(dispense=100)
         self.assertEqual(self.p200.speeds['dispense'], 100)
-
-        with self.assertRaises(KeyError):
-            self.p200.set_speed('mix', 100)
 
     def test_transfer_no_volume(self):
         self.p200.aspirate = mock.Mock()

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -231,7 +231,6 @@ class PipetteTest(unittest.TestCase):
 
     def test_invalid_aspirate(self):
         self.assertRaises(RuntimeWarning, self.p200.aspirate, 500)
-        self.assertRaises(IndexError, self.p200.aspirate, 1)
 
     def test_dispense(self):
         self.p200.aspirate(100)
@@ -293,11 +292,15 @@ class PipetteTest(unittest.TestCase):
             "Delaying 1 seconds")
 
     def test_set_speed(self):
-        self.assertEqual(self.p200.speed, 300)
 
-        self.p200.set_speed(100)
+        self.p200.set_speed('aspirate', 100)
+        self.assertEqual(self.p200.speeds['aspirate'], 100)
 
-        self.assertEqual(self.p200.speed, 100)
+        self.p200.set_speed('dispense', 100)
+        self.assertEqual(self.p200.speeds['dispense'], 100)
+
+        with self.assertRaises(KeyError):
+            self.p200.set_speed('mix', 100)
 
     def test_transfer_no_volume(self):
         self.p200.aspirate = mock.Mock()

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -10,12 +10,19 @@ class RobotTest(unittest.TestCase):
         self.robot = Robot.get_instance()
         self.robot.connect()
         self.robot.home()
+        self.robot.clear()
 
     def test_robot_move_to(self):
         self.robot.move_to((Deck(), (100, 0, 0)))
         self.robot.run()
         position = self.robot._driver.get_head_position()['current']
         self.assertEqual(position, (100, 0, 0))
+
+    def test_home(self):
+        self.robot.clear()
+        self.robot.home()
+        self.assertEquals(len(self.robot._commands), 1)
+        self.robot.run()
 
     def test_robot_pause_and_resume(self):
         self.robot.move_to((Deck(), (100, 0, 0)))

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -52,7 +52,6 @@ class RobotTest(unittest.TestCase):
 
         def _run():
             self.robot.run()
-            self.assertEqual(len(self.robot._commands), 0)
 
         thread = threading.Thread(target=_run)
         thread.start()
@@ -69,7 +68,6 @@ class RobotTest(unittest.TestCase):
 
         def _run():
             self.robot.run()
-            self.assertEqual(len(self.robot._commands), 0)
 
         self.robot.pause()
 
@@ -81,3 +79,6 @@ class RobotTest(unittest.TestCase):
         self.assertEqual(len(self.robot._commands) > 0, True)
 
         self.robot.resume()
+
+        thread.join(1)
+        self.assertEqual(len(self.robot._commands), 0)

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -13,17 +13,35 @@ class RobotTest(unittest.TestCase):
         self.robot.home()
         self.robot.clear()
 
+    def test_disconnect(self):
+        self.robot.disconnect()
+        res = self.robot.is_connected()
+        self.assertEquals(bool(res), False)
+
+    def test_get_connected_port(self):
+        res = self.robot.get_connected_port()
+        self.assertEquals(res, self.robot._driver.VIRTUAL_SMOOTHIE_PORT)
+
     def test_robot_move_to(self):
         self.robot.move_to((Deck(), (100, 0, 0)))
         self.robot.run()
         position = self.robot._driver.get_head_position()['current']
         self.assertEqual(position, (100, 0, 0))
 
+    def test_move_head(self):
+        self.robot.move_head(x=100, y=0, z=20)
+        current = self.robot._driver.get_head_position()['current']
+        self.assertEquals(current, (100, 0, 20))
+
     def test_home(self):
         self.robot.clear()
         self.robot.home()
         self.assertEquals(len(self.robot._commands), 1)
         self.robot.run()
+
+        self.robot.clear()
+        self.robot.home(now=True)
+        self.assertEquals(len(self.robot._commands), 0)
 
     def test_robot_pause_and_resume(self):
         self.robot.move_to((Deck(), (100, 0, 0)))


### PR DESCRIPTION
This PR:

1. Adds speed properties to aspirate and dispense, set with for example `p200.set_speed(aspirate=300)`
2. Adds optional 3rd argument to aspirate and dispense, `rate=float` which is a percentage of the default speeds.
3. Makes the robot.home() command queueable so it can be called within a protocol. Calling `robot.home(now=True)` will bypass the command queue