### PR TITLE
77 s diagnostics

### DIFF
--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -409,24 +409,22 @@ class CNCDriver(object):
         return arrived
 
     def home(self, *axis):
-        home_command = self.HOME
         axis_to_home = ''
         for a in axis:
             ax = ''.join(sorted(a)).upper()
             if ax in 'ABXYZ':
                 axis_to_home += ax
-        if axis_to_home:
-            res = self.send_command(home_command + axis_to_home)
-            if res == b'ok':
-                # the axis aren't necessarily set to 0.0
-                # values after homing, so force it
-                pos_args = {}
-                for l in axis_to_home:
-                    self.axis_homed[l.lower()] = True
-                    pos_args[l] = 0
-                return self.set_position(**pos_args)
-            else:
-                return False
+        if not axis_to_home:
+            axis_to_home = 'ABXYZ'
+        res = self.send_command(self.HOME + axis_to_home)
+        if res == b'ok':
+            # the axis aren't necessarily set to 0.0
+            # values after homing, so force it
+            pos_args = {}
+            for l in axis_to_home:
+                self.axis_homed[l.lower()] = True
+                pos_args[l] = 0
+            return self.set_position(**pos_args)
         else:
             return False
 

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -212,6 +212,7 @@ class CNCDriver(object):
     def stop(self):
         if self.current_commands:
             self.stopped.set()
+            self.can_move.set()
         else:
             self.resume()
 
@@ -307,9 +308,6 @@ class CNCDriver(object):
             raise ValueError('Invalid coordinate mode: ' + mode)
 
     def move_plunger(self, mode='absolute', **kwargs):
-        if 'absolute' in kwargs:
-            raise ValueError('absolute parameter is obsolete, ' +
-                             'please use mode=(absolute|relative)')
 
         self.set_coordinate_system(mode)
 
@@ -320,9 +318,6 @@ class CNCDriver(object):
         return self.consume_move_commands([args], 0.1)
 
     def move_head(self, mode='absolute', **kwargs):
-        if 'absolute' in kwargs:
-            raise ValueError('absolute parameter is obsolete, ' +
-                             'please use mode=(absolute|relative)')
 
         self.set_coordinate_system(mode)
         current = self.get_head_position()['target']

--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -45,9 +45,9 @@ class CNCDriver(object):
     ABSOLUTE_POSITIONING = 'G90'
     RELATIVE_POSITIONING = 'G91'
 
-    VERSION = 'version'
-
     GET_OT_VERSION = 'config-get sd ot_version'
+    GET_FIRMWARE_VERSION = 'version'
+    GET_CONFIG_VERSION = 'config-get sd version'
     GET_STEPS_PER_MM = {
         'x': 'config-get sd alpha_steps_per_mm',
         'y': 'config-get sd beta_steps_per_mm'
@@ -154,10 +154,11 @@ class CNCDriver(object):
 
     def connect_to_virtual_smoothie(self):
         settings = {
-                'ot_version': 'one_pro',
-                'alpha_steps_per_mm': 80.0,
-                'beta_steps_per_mm': 80.0
-            }
+            'ot_version': 'one_pro',
+            'version': 'v1.0.3',        # config version
+            'alpha_steps_per_mm': 80.0,
+            'beta_steps_per_mm': 80.0
+        }
         self.connection = VirtualSmoothie('v1.0.5', settings)
         return self.calm_down()
 
@@ -509,6 +510,21 @@ class CNCDriver(object):
             raise ValueError('{} is not an ot_version'.format(res))
         self.ot_version = res
         return self.ot_version
+
+    def get_firmware_version(self):
+        res = self.send_command(self.GET_FIRMWARE_VERSION)
+        res = res.decode().split(' ')[-1]
+        # the version is returned as a JSON dict, the version is a string
+        # but not wrapped in double-quotes as JSON requires...
+        # aka --> {"version":v1.0.5}
+        self.firmware_version = res.split(':')[-1][:-1]
+        return self.firmware_version
+
+    def get_config_version(self):
+        res = self.send_command(self.GET_CONFIG_VERSION)
+        res = res.decode().split(' ')[-1]
+        self.config_version = res
+        return self.config_version
 
     def get_steps_per_mm(self, axis):
         if axis not in self.GET_STEPS_PER_MM:

--- a/opentrons_sdk/drivers/virtual_smoothie.py
+++ b/opentrons_sdk/drivers/virtual_smoothie.py
@@ -97,7 +97,7 @@ class VirtualSmoothie(object):
 
         for axis in axis_list:
             arguments[axis.upper()] = 0.0
-            self.endstop['min_' + axis] = 0
+            self.endstop['min_' + axis.lower()] = 0
 
         self.process_set_position_command(arguments)
 

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -292,18 +292,17 @@ class Robot(object):
     def get_connected_port(self):
         return self._driver.get_connected_port()
 
-    def switches(self):
-        return self._driver.get_endstop_switches()
-
-    def versions(self):
-        """
-        Returns the software, firmware, config, and robot versions
-        """
+    def diagnostics(self):
         return {
-            'software': '2.0.0',
-            'firmware': self._driver.get_firmware_version(),
-            'config': self._driver.get_config_version(),
-            'model': self._driver.get_ot_version(),
+            'version': {
+                'firmware': self._driver.get_firmware_version(),
+                'config': self._driver.get_config_version(),
+                'robot': self._driver.get_ot_version(),
+            },
+            'state': {
+                'axis_homed': self._driver.axis_homed,
+                'switches': self._driver.get_endstop_switches()
+            }
         }
 
     def mosfet(self, mosfet_index, state, now=False):

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -292,18 +292,19 @@ class Robot(object):
     def get_connected_port(self):
         return self._driver.get_connected_port()
 
+    def versions(self):
+        # TODO: Store these versions in config
+        return {
+            'firmware': self._driver.get_firmware_version(),
+            'config': self._driver.get_config_version(),
+            'robot': self._driver.get_ot_version(),
+        }
+
     def diagnostics(self):
         # TODO: Store these versions in config
         return {
-            'version': {
-                'firmware': self._driver.get_firmware_version(),
-                'config': self._driver.get_config_version(),
-                'robot': self._driver.get_ot_version(),
-            },
-            'state': {
-                'axis_homed': self._driver.axis_homed,
-                'switches': self._driver.get_endstop_switches()
-            }
+            'axis_homed': self._driver.axis_homed,
+            'switches': self._driver.get_endstop_switches()
         }
 
     def mosfet(self, mosfet_index, state, now=False):

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -293,6 +293,7 @@ class Robot(object):
         return self._driver.get_connected_port()
 
     def diagnostics(self):
+        # TODO: Store these versions in config
         return {
             'version': {
                 'firmware': self._driver.get_firmware_version(),

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -295,6 +295,17 @@ class Robot(object):
     def switches(self):
         return self._driver.get_endstop_switches()
 
+    def versions(self):
+        """
+        Returns the software, firmware, config, and robot versions
+        """
+        return {
+            'software': '2.0.0',
+            'firmware': self._driver.get_firmware_version(),
+            'config': self._driver.get_config_version(),
+            'model': self._driver.get_ot_version(),
+        }
+
     def mosfet(self, mosfet_index, state, now=False):
         def _do():
             self._driver.set_mosfet(mosfet_index, state)

--- a/tests/opentrons_sdk/drivers/test_motor.py
+++ b/tests/opentrons_sdk/drivers/test_motor.py
@@ -71,11 +71,20 @@ class OpenTronsTest(unittest.TestCase):
         self.assertDictEqual(coords, expected_coords)
 
     def test_home(self):
+
+        expected = {
+            'x': False, 'y': False, 'z': False, 'a': False, 'b': False}
+        self.assertDictEqual(self.motor.axis_homed, expected)
+
         success = self.motor.home('x', 'y')
         self.assertTrue(success)
 
         success = self.motor.home('ba')
         self.assertTrue(success)
+
+        expected = {
+            'x': True, 'y': True, 'z': False, 'a': True, 'b': True}
+        self.assertDictEqual(self.motor.axis_homed, expected)
 
     def test_limit_hit_exception(self):
         self.motor.home()

--- a/tests/opentrons_sdk/drivers/test_motor.py
+++ b/tests/opentrons_sdk/drivers/test_motor.py
@@ -35,6 +35,13 @@ class OpenTronsTest(unittest.TestCase):
         self.assertEquals(res, True)
         self.assertEquals(self.motor.head_speed, 4000)
 
+    def test_get_connected_port(self):
+        res = self.motor.get_connected_port()
+        self.assertEquals(res, self.motor.VIRTUAL_SMOOTHIE_PORT)
+        self.motor.disconnect()
+        res = self.motor.get_connected_port()
+        self.assertEquals(res, None)
+
     def test_pause_resume(self):
         self.motor.home()
 
@@ -53,6 +60,39 @@ class OpenTronsTest(unittest.TestCase):
         self.motor.resume()
         done.wait()
 
+        coords = self.motor.get_head_position()
+        expected_coords = {
+            'target': (100, 0, 0),
+            'current': (100, 0, 0)
+        }
+        self.assertDictEqual(coords, expected_coords)
+
+    def test_stop(self):
+        self.motor.home()
+
+        self.motor.pause()
+
+        done = Event()
+        done.clear()
+
+        def _move_head():
+            self.motor.move_head(x=100, y=0, z=0)
+            done.set()
+
+        thread = Thread(target=_move_head)
+        thread.start()
+
+        self.motor.stop()
+        done.wait()
+
+        coords = self.motor.get_head_position()
+        expected_coords = {
+            'target': (0, 250, 120),
+            'current': (0, 250, 120)
+        }
+        self.assertDictEqual(coords, expected_coords)
+
+        self.motor.move_head(x=100, y=0, z=0)
         coords = self.motor.get_head_position()
         expected_coords = {
             'target': (100, 0, 0),

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -63,33 +63,72 @@ class RobotTest(unittest.TestCase):
         self.robot.mosfet(0, True, now=True)
         self.assertEqual(len(self.robot._commands), 0)
 
-    def test_switches(self):
-        res = self.robot.switches()
+    def test_diagnostics(self):
+        res = self.robot.diagnostics()
         expected = {
-            'x': False,
-            'y': False,
-            'z': False,
-            'a': False,
-            'b': False
+            'version': {
+                'config': 'v1.0.3',
+                'firmware': 'v1.0.5',
+                'robot': 'one_pro'
+            },
+            'state': {
+                'axis_homed': {
+                    'x': True, 'y': True, 'z': True, 'a': True, 'b': True
+                },
+                'switches': {
+                    'x': False,
+                    'y': False,
+                    'z': False,
+                    'a': False,
+                    'b': False
+                }
+            }
         }
-        self.assertEquals(res, expected)
-        self.assertRaises(RuntimeWarning, self.robot.move_head, x=-199)
-        res = self.robot.switches()
-        expected = {
-            'x': True,
-            'y': False,
-            'z': False,
-            'a': False,
-            'b': False
-        }
-        self.assertEquals(res, expected)
+        self.assertDictEqual(res, expected)
 
-    def test_version(self):
-        versions = self.robot.versions()
+        self.robot.connect()
+        self.assertRaises(RuntimeWarning, self.robot.move_head, x=-199)
+        res = self.robot.diagnostics()
         expected = {
-            'software': '2.0.0',
-            'config': 'v1.0.3',
-            'firmware': 'v1.0.5',
-            'model': 'one_pro'
+            'version': {
+                'config': 'v1.0.3',
+                'firmware': 'v1.0.5',
+                'robot': 'one_pro'
+            },
+            'state': {
+                'axis_homed': {
+                    'x': False, 'y': False, 'z': False, 'a': False, 'b': False
+                },
+                'switches': {
+                    'x': True,
+                    'y': False,
+                    'z': False,
+                    'a': False,
+                    'b': False
+                }
+            }
         }
-        self.assertDictEqual(versions, expected)
+        self.assertDictEqual(res, expected)
+
+        self.robot.home('x')
+        res = self.robot.diagnostics()
+        expected = {
+            'version': {
+                'config': 'v1.0.3',
+                'firmware': 'v1.0.5',
+                'robot': 'one_pro'
+            },
+            'state': {
+                'axis_homed': {
+                    'x': True, 'y': False, 'z': False, 'a': False, 'b': False
+                },
+                'switches': {
+                    'x': False,
+                    'y': False,
+                    'z': False,
+                    'a': False,
+                    'b': False
+                }
+            }
+        }
+        self.assertDictEqual(res, expected)

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -63,25 +63,27 @@ class RobotTest(unittest.TestCase):
         self.robot.mosfet(0, True, now=True)
         self.assertEqual(len(self.robot._commands), 0)
 
+    def test_versions(self):
+        res = self.robot.versions()
+        expected = {
+            'config': 'v1.0.3',
+            'firmware': 'v1.0.5',
+            'robot': 'one_pro'
+        }
+        self.assertDictEqual(res, expected)
+
     def test_diagnostics(self):
         res = self.robot.diagnostics()
         expected = {
-            'version': {
-                'config': 'v1.0.3',
-                'firmware': 'v1.0.5',
-                'robot': 'one_pro'
+            'axis_homed': {
+                'x': True, 'y': True, 'z': True, 'a': True, 'b': True
             },
-            'state': {
-                'axis_homed': {
-                    'x': True, 'y': True, 'z': True, 'a': True, 'b': True
-                },
-                'switches': {
-                    'x': False,
-                    'y': False,
-                    'z': False,
-                    'a': False,
-                    'b': False
-                }
+            'switches': {
+                'x': False,
+                'y': False,
+                'z': False,
+                'a': False,
+                'b': False
             }
         }
         self.assertDictEqual(res, expected)
@@ -90,22 +92,15 @@ class RobotTest(unittest.TestCase):
         self.assertRaises(RuntimeWarning, self.robot.move_head, x=-199)
         res = self.robot.diagnostics()
         expected = {
-            'version': {
-                'config': 'v1.0.3',
-                'firmware': 'v1.0.5',
-                'robot': 'one_pro'
+            'axis_homed': {
+                'x': False, 'y': False, 'z': False, 'a': False, 'b': False
             },
-            'state': {
-                'axis_homed': {
-                    'x': False, 'y': False, 'z': False, 'a': False, 'b': False
-                },
-                'switches': {
-                    'x': True,
-                    'y': False,
-                    'z': False,
-                    'a': False,
-                    'b': False
-                }
+            'switches': {
+                'x': True,
+                'y': False,
+                'z': False,
+                'a': False,
+                'b': False
             }
         }
         self.assertDictEqual(res, expected)
@@ -113,22 +108,15 @@ class RobotTest(unittest.TestCase):
         self.robot.home('x')
         res = self.robot.diagnostics()
         expected = {
-            'version': {
-                'config': 'v1.0.3',
-                'firmware': 'v1.0.5',
-                'robot': 'one_pro'
+            'axis_homed': {
+                'x': True, 'y': False, 'z': False, 'a': False, 'b': False
             },
-            'state': {
-                'axis_homed': {
-                    'x': True, 'y': False, 'z': False, 'a': False, 'b': False
-                },
-                'switches': {
-                    'x': False,
-                    'y': False,
-                    'z': False,
-                    'a': False,
-                    'b': False
-                }
+            'switches': {
+                'x': False,
+                'y': False,
+                'z': False,
+                'a': False,
+                'b': False
             }
         }
         self.assertDictEqual(res, expected)

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -83,3 +83,13 @@ class RobotTest(unittest.TestCase):
             'b': False
         }
         self.assertEquals(res, expected)
+
+    def test_version(self):
+        versions = self.robot.versions()
+        expected = {
+            'software': '2.0.0',
+            'config': 'v1.0.3',
+            'firmware': 'v1.0.5',
+            'model': 'one_pro'
+        }
+        self.assertDictEqual(versions, expected)


### PR DESCRIPTION
This PR adds `robot.diagnostics()`, which returns a dict containing version data, and robot state data. The versions include firmware, config, and OT models. The robot state contains the endstop switches, and a boolean for whether an axis has been homed or not (all reset to `False` after a connection is reset)