### PR TITLE
129-s-move-instrument-placeable-assignment-from-robot-to-instrument

### DIFF
--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -58,7 +58,7 @@ class Pipette(object):
     def move_to(self, location, create_path=True):
         if location:
             self.associate_placeable(location)
-            self.robot.move_to(location, instrument=self)
+            self.robot.move_to(location, instrument=self, create_path=create_path)
 
         return self
 
@@ -75,7 +75,7 @@ class Pipette(object):
     def go_to(self, location):
         return self.move_to(location, create_path=False)
 
-    def go_to_top(self, location, offset=None):
+    def go_to_top(self, location):
         return self.move_to_top(location, create_path=False)
 
     def go_to_bottom(self, location):

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -58,7 +58,10 @@ class Pipette(object):
     def move_to(self, location, create_path=True):
         if location:
             self.associate_placeable(location)
-            self.robot.move_to(location, instrument=self, create_path=create_path)
+            self.robot.move_to(
+                location,
+                instrument=self,
+                create_path=create_path)
 
         return self
 

--- a/opentrons_sdk/labware/instruments.py
+++ b/opentrons_sdk/labware/instruments.py
@@ -16,19 +16,13 @@ class Pipette(object):
             min_volume=0,
             trash_container=None,
             tip_racks=None,
-            aspirate_speed=300,
-            dispense_speed=500):
+            speed=300):
 
         self.positions = {
             'top': None,
             'bottom': None,
             'blow_out': None,
             'drop_tip': None
-        }
-
-        self.speeds = {
-            'aspirate': aspirate_speed,
-            'dispense': dispense_speed
         }
 
         self.axis = axis
@@ -53,6 +47,8 @@ class Pipette(object):
         self.placeables = []
 
         self.calibrator = Calibrator(self.robot._deck, self.calibration_data)
+
+        self.set_speed(speed)
 
     def associate_location(self, location):
         placeable, _ = containers.unpack_location(location)
@@ -88,7 +84,7 @@ class Pipette(object):
         bottom_location = (placeable, placeable.from_center(x=0, y=0, z=-1))
         return self.go_to(bottom_location)
 
-    def aspirate(self, volume=None, location=None, rate=1.0):
+    def aspirate(self, volume=None, location=None):
 
         if not isinstance(volume, (int, float, complex)):
             if volume and not location:
@@ -107,10 +103,8 @@ class Pipette(object):
         distance = self.plunge_distance(self.current_volume)
         destination = self.positions['bottom'] - distance
 
-        speed = self.speeds['aspirate'] * rate
-
         def _do_aspirate():
-            self.plunger.speed(speed)
+            self.plunger.speed(self.speed)
             self.plunger.move(destination)
 
         description = "Aspirating {0}uL at {1}".format(volume, str(location))
@@ -119,7 +113,7 @@ class Pipette(object):
 
         return self
 
-    def dispense(self, volume=None, location=None, rate=1.0):
+    def dispense(self, volume=None, location=None):
 
         if not isinstance(volume, (int, float, complex)):
             if volume and not location:
@@ -138,10 +132,8 @@ class Pipette(object):
             distance = self.plunge_distance(self.current_volume)
             destination = self.positions['bottom'] - distance
 
-            speed = self.speeds['dispense'] * rate
-
             def _do():
-                self.plunger.speed(speed)
+                self.plunger.speed(self.speed)
                 self.plunger.move(destination)
 
             description = "Dispensing {0}uL at {1}".format(
@@ -387,9 +379,13 @@ class Pipette(object):
         self.robot.add_command(Command(do=_do, description=description))
         return self
 
-    def set_speed(self, **kwargs):
-        keys = {'head', 'aspirate', 'dispense'} & kwargs.keys()
-        for key in keys:
-            self.speeds[key] = kwargs.get(key)
+    def set_speed(self, rate):
+        self.speed = rate
+
+        def _do():
+            self.plunger.speed(rate)
+
+        description = "Setting speed to {}mm/minute".format(rate)
+        self.robot.add_command(Command(do=_do, description=description))
 
         return self

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -56,8 +56,10 @@ class Robot(object):
 
         class InstrumentMotor():
 
-            def move(self, value, mode='absolute'):
+            def move(self, value, speed=None, mode='absolute'):
                 kwargs = {axis: value}
+                if speed:
+                    self.speed(speed)
 
                 return robot_self._driver.move_plunger(
                     mode=mode, **kwargs

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -126,7 +126,7 @@ class Robot(object):
     def move_head(self, *args, **kwargs):
         self._driver.move_head(*args, **kwargs)
 
-    def move_to(self, location, instrument=None, create_path=True):
+    def move_to(self, location, instrument=None, create_path=True, now=False):
         placeable, coordinates = containers.unpack_location(location)
 
         if instrument:
@@ -150,10 +150,10 @@ class Robot(object):
                     y=coordinates[1],
                     z=coordinates[2])
 
-        # description = "Moving head to {} {}".format(
-        #     str(placeable),
-        #     coordinates)
-        self.add_command(Command(do=_do))
+        if now:
+            _do()
+        else:
+            self.add_command(Command(do=_do))
 
     @property
     def actions(self):

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -123,8 +123,6 @@ class Robot(object):
         placeable, coordinates = containers.unpack_location(location)
 
         if instrument:
-            # add to the list of instument-container mappings
-            instrument.placeables.append(placeable)
             coordinates = instrument.calibrator.convert(
                 placeable,
                 coordinates)
@@ -149,16 +147,6 @@ class Robot(object):
         #     str(placeable),
         #     coordinates)
         self.add_command(Command(do=_do))
-
-    def move_to_top(self, location, instrument=None, create_path=True):
-        placeable, coordinates = containers.unpack_location(location)
-        top_location = (placeable, placeable.from_center(x=0, y=0, z=1))
-        self.move_to(top_location, instrument, create_path)
-
-    def move_to_bottom(self, location, instrument=None, create_path=True):
-        placeable, coordinates = containers.unpack_location(location)
-        bottom_location = (placeable, placeable.from_center(x=0, y=0, z=-1))
-        self.move_to(bottom_location, instrument, create_path)
 
     @property
     def actions(self):

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -56,10 +56,8 @@ class Robot(object):
 
         class InstrumentMotor():
 
-            def move(self, value, speed=None, mode='absolute'):
+            def move(self, value, mode='absolute'):
                 kwargs = {axis: value}
-                if speed:
-                    self.speed(speed)
 
                 return robot_self._driver.move_plunger(
                     mode=mode, **kwargs
@@ -92,15 +90,22 @@ class Robot(object):
             port = self._driver.VIRTUAL_SMOOTHIE_PORT
         return self._driver.connect(port)
 
-    def home(self, *args):
-        if self._driver.calm_down():
-            if args:
-                return self._driver.home(*args)
+    def home(self, *args, **kwargs):
+        def _do():
+            if self._driver.calm_down():
+                if args:
+                    return self._driver.home(*args)
+                else:
+                    self._driver.home('z')
+                    return self._driver.home('x', 'y', 'b', 'a')
             else:
-                self._driver.home('z')
-                return self._driver.home('x', 'y', 'b', 'a')
+                return False
+
+        if kwargs.get('now'):
+            return _do()
         else:
-            return False
+            description = "Homing Robot"
+            self.add_command(Command(do=_do, description=description))
 
     def add_command(self, command):
         if command.description:

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -42,8 +42,7 @@ class PipetteTest(unittest.TestCase):
             axis="a",
             name="p1000",
             channels=1,
-            aspirate_speed=300,
-            dispense_speed=500
+            speed=300
         )
         result = list(self.robot.get_instruments('p1000'))
         self.assertListEqual(result, [('A', self.p1000)])
@@ -95,14 +94,14 @@ class PipetteTest(unittest.TestCase):
             expected_calibration_data)
 
     def test_aspirate_rate(self):
-        self.p200.set_speed(aspirate=300, dispense=500)
+        self.p200.set_speed(500)
         self.robot.clear()
         self.p200.plunger.speed = mock.Mock()
-        self.p200.aspirate(100, rate=2.0).dispense(rate=.5)
+        self.p200.aspirate(100).dispense()
         self.robot.run()
         expected = [
-            mock.call(600.0),
-            mock.call(250.0)
+            mock.call(500.0),
+            mock.call(500.0)
         ]
         self.assertEquals(self.p200.plunger.speed.mock_calls, expected)
 
@@ -303,11 +302,8 @@ class PipetteTest(unittest.TestCase):
 
     def test_set_speed(self):
 
-        self.p200.set_speed(aspirate=100)
-        self.assertEqual(self.p200.speeds['aspirate'], 100)
-
-        self.p200.set_speed(dispense=100)
-        self.assertEqual(self.p200.speeds['dispense'], 100)
+        self.p200.set_speed(100)
+        self.assertEqual(self.p200.speed, 100)
 
     def test_transfer_no_volume(self):
         self.p200.aspirate = mock.Mock()

--- a/tests/opentrons_sdk/labware/test_instruments.py
+++ b/tests/opentrons_sdk/labware/test_instruments.py
@@ -50,10 +50,14 @@ class PipetteTest(unittest.TestCase):
     def test_placeables_reference(self):
 
         self.p200.aspirate(100, self.plate[0])
+        self.p200.dispense(100, self.plate[0])
+        self.p200.aspirate(100, self.plate[20])
+        self.p200.aspirate(100, self.plate[1])
 
         expected = [
             self.plate[0],
-            self.plate[0]
+            self.plate[20],
+            self.plate[1]
         ]
 
         self.assertEquals(self.p200.placeables, expected)

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -11,12 +11,37 @@ class RobotTest(unittest.TestCase):
         self.robot = Robot.get_instance()
         self.robot.connect()
         self.robot.home()
+        self.robot.clear()
+
+    def test_disconnect(self):
+        self.robot.disconnect()
+        res = self.robot.is_connected()
+        self.assertEquals(bool(res), False)
+
+    def test_get_connected_port(self):
+        res = self.robot.get_connected_port()
+        self.assertEquals(res, self.robot._driver.VIRTUAL_SMOOTHIE_PORT)
 
     def test_robot_move_to(self):
         self.robot.move_to((Deck(), (100, 0, 0)))
         self.robot.run()
         position = self.robot._driver.get_head_position()['current']
         self.assertEqual(position, (100, 0, 0))
+
+    def test_move_head(self):
+        self.robot.move_head(x=100, y=0, z=20)
+        current = self.robot._driver.get_head_position()['current']
+        self.assertEquals(current, (100, 0, 20))
+
+    def test_home(self):
+        self.robot.clear()
+        self.robot.home()
+        self.assertEquals(len(self.robot._commands), 1)
+        self.robot.run()
+
+        self.robot.clear()
+        self.robot.home(now=True)
+        self.assertEquals(len(self.robot._commands), 0)
 
     def test_robot_pause_and_resume(self):
         self.robot.move_to((Deck(), (100, 0, 0)))


### PR DESCRIPTION
This PR:

1. Associates a placeable to the instrument inside the instrument
2. Refactors `Pipette.go_to()` and `Pipette.move_to()`
3. Adds `Pipette.move_to_bottom()`, `Pipette.move_to_top()`, `Pipette.go_to_bottom()`, and `Pipette.go_to_bottom()`,