### PR TITLE
Grid containers, support for multi-cannel pipettes

### DIFF
--- a/opentrons_sdk/containers/placeable.py
+++ b/opentrons_sdk/containers/placeable.py
@@ -263,7 +263,6 @@ class Deck(Placeable):
 class Well(Placeable):
     pass
 
-
 class Slot(Placeable):
     pass
 

--- a/opentrons_sdk/containers/placeable.py
+++ b/opentrons_sdk/containers/placeable.py
@@ -263,6 +263,7 @@ class Deck(Placeable):
 class Well(Placeable):
     pass
 
+
 class Slot(Placeable):
     pass
 

--- a/opentrons_sdk/containers/placeable.py
+++ b/opentrons_sdk/containers/placeable.py
@@ -261,9 +261,7 @@ class Deck(Placeable):
 
 
 class Well(Placeable):
-    def __repr__(self):
-        return __str__(self)
-
+    pass
 
 class Slot(Placeable):
     pass

--- a/opentrons_sdk/containers/placeable.py
+++ b/opentrons_sdk/containers/placeable.py
@@ -3,6 +3,8 @@ import numbers
 from collections import OrderedDict
 from opentrons_sdk.util.vector import Vector
 
+import re
+
 
 def unpack_location(location):
     coordinates = None
@@ -58,7 +60,8 @@ class Placeable(object):
     def __str__(self):
         if not self.parent:
             return '<{}>'.format(self.__class__.__name__)
-        return '<{} {}>'.format(self.__class__.__name__, self.get_name())
+        return '<{} {}>'.format(
+            self.__class__.__name__, self.get_name())
 
     def __iter__(self):
         return iter(self.children_by_reference.keys())
@@ -257,11 +260,82 @@ class Deck(Placeable):
         return query in self.containers()
 
 
+class Well(Placeable):
+    def __repr__(self):
+        return __str__(self)
+
+
 class Slot(Placeable):
     pass
 
 
 class Container(Placeable):
+    def __init__(self, *args, **kwargs):
+        super(Container, self).__init__(*args, **kwargs)
+        self.grid = None
+        self.grid_transposed = None
+
+    def invalidate_grid(self):
+        self.grid = None
+        self.grid_transposed = None
+
+    def calculate_grid(self):
+        if self.grid is None:
+            self.grid = self.get_wellseries(self.get_grid())
+
+        if self.grid_transposed is None:
+            self.grid_transposed = self.get_wellseries(
+                self.transpose(
+                    self.get_grid()))
+
+    def get_grid(self):
+        rows = OrderedDict()
+        index_pattern = r'^([A-Za-z]+)([0-9]+)$'
+        for name in self.children_by_name:
+            match = re.match(index_pattern, name)
+            if match:
+                col, row = match.groups(0)
+                if row not in rows:
+                    rows[row] = OrderedDict()
+                rows[row][col] = (row, col)
+
+        return rows
+
+    def transpose(self, rows):
+        res = OrderedDict()
+        for row, cols in rows.items():
+            for col, cell in cols.items():
+                if col not in res:
+                    res[col] = OrderedDict()
+                res[col][row] = cell
+        return res
+
+    def get_wellseries(self, matrix):
+        res = OrderedDict()
+        for row, cells in matrix.items():
+            if row not in res:
+                res[row] = OrderedDict()
+            for col, cell in cells.items():
+                res[row][col] = self.children_by_name[
+                    ''.join(reversed(cell))
+                ]
+            res[row] = WellSeries(res[row])
+        return WellSeries(res)
+
+    @property
+    def rows(self):
+        self.calculate_grid()
+        return self.grid
+
+    @property
+    def columns(self):
+        self.calculate_grid()
+        return self.grid_transposed
+
+    @property
+    def cols(self):
+        return self.columns
+
     def well(self, name):
         return self.get_child_by_name(name)
 
@@ -269,5 +343,27 @@ class Container(Placeable):
         return self.get_children()
 
 
-class Well(Placeable):
-    pass
+class WellSeries(Placeable):
+    def __init__(self, items):
+        self.items = items
+        self.values = list(self.items.values())
+        self.offset = 0
+
+    def set_offset(self, offset):
+        self.offset = offset
+
+    def __iter__(self):
+        return iter(self.values)
+
+    def __str__(self):
+        return '<Series: {}>'.format(
+            ' '.join([str(well) for well in self.values]))
+
+    def __getitem__(self, index):
+        if isinstance(index, str):
+            return self.items[index]
+        else:
+            return list(self.values)[index]
+
+    def __getattr__(self, name):
+        return getattr(self.values[self.offset], name)

--- a/tests/opentrons_sdk/containers/test_grid.py
+++ b/tests/opentrons_sdk/containers/test_grid.py
@@ -1,6 +1,6 @@
 import unittest
 
-import opentrons_sdk.containers as containers
+from opentrons_sdk import containers
 from opentrons_sdk.labware import instruments
 from opentrons_sdk.robot import Robot
 

--- a/tests/opentrons_sdk/containers/test_grid.py
+++ b/tests/opentrons_sdk/containers/test_grid.py
@@ -1,7 +1,7 @@
 import unittest
 
 from opentrons_sdk import containers
-from opentrons_sdk.labware import instruments
+from opentrons_sdk import instruments
 from opentrons_sdk.robot import Robot
 
 

--- a/tests/opentrons_sdk/containers/test_grid.py
+++ b/tests/opentrons_sdk/containers/test_grid.py
@@ -1,0 +1,84 @@
+import unittest
+
+import opentrons_sdk.containers as containers
+from opentrons_sdk.labware import instruments
+from opentrons_sdk.robot import Robot
+
+
+class GridTestCase(unittest.TestCase):
+    def setUp(self):
+        Robot.reset()
+        self.plate = containers.load('96-flat', 'A2')
+
+    def test_rows_cols(self):
+        plate = self.plate
+        wells = [
+            plate.rows[1]['B'],
+            plate.rows['2']['B'],
+            plate.rows['2'][1],
+            plate.rows[1][1],
+            plate.cols['B']['2'],
+            plate.cols[1]['2'],
+            plate.cols[1][1],
+            plate['B2'],
+            plate[9]
+        ]
+
+        for well, next_well in zip(wells[:-1], wells[1:]):
+            self.assertEqual(well, next_well)
+
+    def test_placeable(self):
+        plate = self.plate
+        self.assertEqual(plate.rows[0].center(plate), (16.7, 19.7, 5.25))
+        self.assertEqual(plate.rows[1].center(plate), (16.7, 28.7, 5.25))
+        self.assertEqual(plate.rows[0].center(plate),
+                         plate.cols[0].center(plate))
+
+    def test_serial_dilution(self):
+        plate = containers.load(
+            '96-flat',
+            'B1',
+            'plate'
+        )
+
+        tiprack = containers.load(
+            'tiprack-200ul',  # container type from library
+            'A1',             # slot on deck
+            'tiprack'         # calibration reference for 1.2 compatibility
+        )
+
+        trough = containers.load(
+            'trough-12row',
+            'B1',
+            'trough'
+        )
+
+        trash = containers.load(
+            'point',
+            'A2',
+            'trash'
+        )
+
+        p200 = instruments.Pipette(
+            trash_container=trash,
+            tip_racks=[tiprack],
+            min_volume=10,  # These are variable
+            axis="b",
+            channels=1
+        )
+        p200.set_max_volume(200)
+        p200.calibrate_plunger(top=0, bottom=10, blow_out=12, drop_tip=13)
+
+        for t, col in enumerate(plate.cols):
+            p200.pick_up_tip(tiprack[t])
+
+            p200.aspirate(10, trough[t])
+            p200.dispense(10, col[0])
+
+            for well, next_well in zip(col[:-1], col[1:]):
+                p200.aspirate(10, well)
+                p200.dispense(10, next_well).mix(3)
+
+            p200.drop_tip(trash)
+
+        # TODO: check for successful completion of the protocol


### PR DESCRIPTION
In this PR:
* Infer rows / columns from well indexes in a container
* Introduced WellSeries class to hold a series of wells
* Made WellSeries class a Placeable delegating all calls to a single well within it defined by offset. This way we won't require changes to Pipettes behavior for multi-channel, we will always navigate to the first well within a row, or use the offset.