### PR TITLE
Stream robot updates in API

### DIFF
--- a/opentrons_sdk/containers/placeable.py
+++ b/opentrons_sdk/containers/placeable.py
@@ -57,6 +57,9 @@ class Placeable(object):
         else:
             return self.get_child_by_name(name)
 
+    def __repr__(self):
+        return '/'.join([str(i) for i in reversed(self.get_trace())])
+
     def __str__(self):
         if not self.parent:
             return '<{}>'.format(self.__class__.__name__)

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -8,6 +8,7 @@ from opentrons_sdk.robot.command import Command
 from opentrons_sdk.util import log
 
 from opentrons_sdk.helpers import helpers
+from opentrons_sdk.util.trace import traceable
 
 
 class Robot(object):
@@ -140,6 +141,7 @@ class Robot(object):
     def move_head(self, *args, **kwargs):
         self._driver.move_head(*args, **kwargs)
 
+    @traceable('move-to')
     def move_to(self, location, instrument=None, create_path=True, now=False):
         placeable, coordinates = containers.unpack_location(location)
 

--- a/opentrons_sdk/util/trace.py
+++ b/opentrons_sdk/util/trace.py
@@ -1,0 +1,73 @@
+from functools import wraps
+import inspect
+
+
+def traceable(*args):
+    def _traceable(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            res = f(*args, **kwargs)
+            broker = EventBroker.get_instance()
+
+            # Create the initial dictionary with args that have defaults
+            args_dict = {}
+
+            if inspect.getargspec(f).defaults:
+                args_dict = dict(
+                    zip(
+                        reversed(inspect.getargspec(f).args),
+                        reversed(inspect.getargspec(f).defaults)))
+
+            # Update / insert values for positional args
+            args_dict.update(dict(zip(inspect.getargspec(f).args, args)))
+
+            # Update it with values for named args
+            args_dict.update(kwargs)
+
+            # args_dict = {k: str(v) for k, v in args_dict.items()}
+
+            broker.notify({
+                'name': name,
+                'function': f.__qualname__,
+                'arguments': args_dict,
+                'result': res
+            })
+            return res
+        return decorated
+
+    if len(args) == 1 and callable(args[0]):
+        # No event name override in the args:
+        # @traceable
+        # def foo()
+        f, = args
+        name = f.__qualname__
+        return _traceable(f)
+    else:
+        # Event name is overriden:
+        # @traceable('event-foo')
+        # def foo()
+        name, = args
+        return _traceable
+
+
+class EventBroker(object):
+    _instance = None
+
+    def __init__(self):
+        self.listeners = []
+
+    def add(self, f):
+        self.listeners.append(f)
+
+    def remove(self, f):
+        self.listeners.remove(f)
+
+    def notify(self, arguments):
+        for listener in self.listeners:
+            listener(arguments)
+
+    @classmethod
+    def get_instance(cls):
+        if not cls._instance:
+            cls._instance = EventBroker()
+        return cls._instance

--- a/tests/opentrons_sdk/performance/test_performance.py
+++ b/tests/opentrons_sdk/performance/test_performance.py
@@ -6,8 +6,13 @@ from opentrons_sdk import instruments
 from opentrons_sdk.robot import Robot
 from opentrons_sdk.helpers.helpers import import_calibration_json
 
+from opentrons_sdk.util.trace import EventBroker
+
 
 class PerformanceTest(unittest.TestCase):
+    def setUp(self):
+        self.events = []
+
     def protocol(self):
         robot = Robot.get_instance()
         robot.get_serial_ports_list()
@@ -122,7 +127,11 @@ class PerformanceTest(unittest.TestCase):
         # TODO: optimize robot.run()
         # robot.run()
 
+    def log(self, info):
+        self.events.append(info)
+
     def test_performance(self):
+        EventBroker.get_instance().add(self.log)
         start = time.process_time()
         self.protocol()
         finish = time.process_time()

--- a/tests/opentrons_sdk/util/test_trace.py
+++ b/tests/opentrons_sdk/util/test_trace.py
@@ -1,0 +1,87 @@
+import unittest
+from opentrons_sdk.util.trace import (
+    EventBroker,
+    traceable
+)
+
+
+class TraceTestCase(unittest.TestCase):
+    class MyClass(object):
+        @traceable('my-event-A')
+        def event_A(self, arg1, arg2, arg3='foo'):
+            return 100
+
+        @traceable
+        def event_B(self, arg1):
+            return None
+
+    def setUp(self):
+        self.my_object = TraceTestCase.MyClass()
+        self.events = []
+
+    def log(self, info):
+        self.events.append(info)
+
+    def test_add_listener(self):
+        EventBroker.get_instance().add(self.log)
+        expected_results = []
+
+        # Test positional args
+        self.my_object.event_A(1, 2)
+        expected_results.append({
+            'arguments': {
+                'arg1': 1,
+                'arg2': 2,
+                'arg3': 'foo',
+                'self': self.my_object
+            },
+            'name': 'my-event-A',
+            'function': 'TraceTestCase.MyClass.event_A',
+            'result': 100
+        })
+        print(expected_results[-1])
+        print(self.events[-1])
+        self.assertDictEqual(expected_results[-1], self.events[-1])
+
+        # Test named args
+        self.my_object.event_A(arg1=1, arg2=2)
+        expected_results.append({
+            'arguments': {
+                'arg1': 1,
+                'arg2': 2,
+                'arg3': 'foo',
+                'self': self.my_object
+            },
+            'name': 'my-event-A',
+            'function': 'TraceTestCase.MyClass.event_A',
+            'result': 100
+        })
+        self.assertDictEqual(expected_results[-1], self.events[-1])
+
+        # Override defaults, and use mixed positonal/named args
+        self.my_object.event_A(1, arg2=2, arg3='bar')
+        expected_results.append({
+            'arguments': {
+                'arg1': 1,
+                'arg2': 2,
+                'arg3': 'bar',
+                'self': self.my_object
+            },
+            'name': 'my-event-A',
+            'function': 'TraceTestCase.MyClass.event_A',
+            'result': 100
+        })
+        self.assertDictEqual(expected_results[-1], self.events[-1])
+
+        # Call event with default name
+        self.my_object.event_B(1)
+        expected_results.append({
+            'arguments': {
+                'arg1': 1,
+                'self': self.my_object
+            },
+            'name': 'TraceTestCase.MyClass.event_B',
+            'function': 'TraceTestCase.MyClass.event_B',
+            'result': None
+        })
+        self.assertDictEqual(expected_results[-1], self.events[-1])


### PR DESCRIPTION
In this PR:
* Added `utils.trace.traceable` decorator with optional `name` argument. On each call of the function decorated with it, it will notify listeners of `util.trace.EventBroker`
* Decorated `robot.move_to` with `@traceable`
* Added `traceable` to performance test
* `util/test_trace.py` shows the example of decorating functions registering listeners in `EventBroker`