### PR TITLE
20161018 142300 fix break down movement

### DIFF
--- a/opentrons_sdk/drivers/motor.py
+++ b/opentrons_sdk/drivers/motor.py
@@ -149,26 +149,33 @@ class CNCDriver(object):
             self.connection.close()
         self.connection = None
 
-    def connect(self, port):
+    def connect(self, port, options=None):
         if port == self.VIRTUAL_SMOOTHIE_PORT:
-            return self.connect_to_virtual_smoothie()
+            return self.connect_to_virtual_smoothie(options)
         elif port:
-            return self.connect_to_physical_smoothie(port)
+            return self.connect_to_physical_smoothie(port, options)
 
-    def connect_to_virtual_smoothie(self):
-        settings = {
-            'ot_version': 'one_pro',
-            'version': 'v1.0.3',        # config version
-            'alpha_steps_per_mm': 80.0,
-            'beta_steps_per_mm': 80.0
+    def connect_to_virtual_smoothie(self, options=None):
+        default_options = {
+            'limit_switches': True,
+            'firmware': 'v1.0.5',
+            'config': {
+                'ot_version': 'one_pro',
+                'version': 'v1.0.3',        # config version
+                'alpha_steps_per_mm': 80.0,
+                'beta_steps_per_mm': 80.0
+            }
         }
-        self.connection = VirtualSmoothie('v1.0.5', settings)
+        if not options:
+            options = {}
+        default_options.update(options)
+        self.connection = VirtualSmoothie(default_options)
         return self.calm_down()
 
     def is_connected(self):
         return self.connection and self.connection.isOpen()
 
-    def connect_to_physical_smoothie(self, port):
+    def connect_to_physical_smoothie(self, port, options=None):
         try:
             self.connection = serial.Serial(
                 port=port,

--- a/opentrons_sdk/drivers/virtual_smoothie.py
+++ b/opentrons_sdk/drivers/virtual_smoothie.py
@@ -105,7 +105,6 @@ class VirtualSmoothie(object):
         return 'ok'
 
     def process_move_command(self, arguments):
-        # import pdb; pdb.set_trace()
 
         if not self.absolute:
             for axis in arguments.keys():

--- a/opentrons_sdk/helpers/helpers.py
+++ b/opentrons_sdk/helpers/helpers.py
@@ -18,15 +18,15 @@ def flip_coordinates(coordinates, dimensions):
     return (x, y_size - y, z_size - z)
 
 
-def break_down_travel(p1, p2=Vector(0, 0, 0), increment=5, mode='absolute'):
+def break_down_travel(p1, target, increment=5, mode='absolute'):
     """
-    given two points p1 and p2, this returns a list of
+    given two points p1 and target, this returns a list of
     incremental positions or relative steps
     """
 
-    heading = p2 - p1
+    heading = target - p1
     if mode == 'relative':
-        heading = p1
+        heading = target
     length = heading.length()
 
     length_steps = length / increment

--- a/opentrons_sdk/instruments/pipette.py
+++ b/opentrons_sdk/instruments/pipette.py
@@ -239,10 +239,14 @@ class Pipette(object):
             else:
                 location = self.placeables[-1]
 
-            self.go_to((location, location.from_center(x=1, y=0, z=1)), now=True)
-            self.go_to((location, location.from_center(x=-1, y=0, z=1)), now=True)
-            self.go_to((location, location.from_center(x=0, y=1, z=1)), now=True)
-            self.go_to((location, location.from_center(x=0, y=-1, z=1)), now=True)
+            self.go_to(
+                (location, location.from_center(x=1, y=0, z=1)), now=True)
+            self.go_to(
+                (location, location.from_center(x=-1, y=0, z=1)), now=True)
+            self.go_to(
+                (location, location.from_center(x=0, y=1, z=1)), now=True)
+            self.go_to(
+                (location, location.from_center(x=0, y=-1, z=1)), now=True)
 
         description = 'Touching tip'
         self.robot.add_command(Command(do=_do, description=description))

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -100,7 +100,7 @@ class Robot(object):
         dimensions = self._driver.get_dimensions()
         return helpers.flip_coordinates(coordinates, dimensions)
 
-    def connect(self, port=None):
+    def connect(self, port=None, options=None):
         """
         Connects the motor to a serial port.
 
@@ -109,7 +109,7 @@ class Robot(object):
         """
         if not port:
             port = self._driver.VIRTUAL_SMOOTHIE_PORT
-        return self._driver.connect(port)
+        return self._driver.connect(port, options)
 
     def home(self, *args, **kwargs):
         def _do():
@@ -130,7 +130,7 @@ class Robot(object):
 
     def add_command(self, command):
         if command.description:
-            print("Enqueing:", command.description)
+            # print("Enqueing:", command.description)
             log.info("Enqueing:", command.description)
         self._commands.append(command)
 
@@ -286,6 +286,7 @@ class Robot(object):
 
     def add_container(self, slot, container_name, label):
         container = containers.get_legacy_container(container_name)
+        container.properties['type'] = container_name
         self._deck[slot].add(container, label)
         return container
 

--- a/tests/opentrons_sdk/drivers/test_motor.py
+++ b/tests/opentrons_sdk/drivers/test_motor.py
@@ -14,8 +14,19 @@ class OpenTronsTest(unittest.TestCase):
 
         self.motor = CNCDriver()
 
+        settings = {
+            'limit_switches': True,
+            'firmware': 'v1.0.5',
+            'config': {
+                'ot_version': 'one_pro',
+                'version': 'v1.0.3',        # config version
+                'alpha_steps_per_mm': 80.0,
+                'beta_steps_per_mm': 80.0
+            }
+        }
+
         myport = self.motor.VIRTUAL_SMOOTHIE_PORT
-        success = self.motor.connect(myport)
+        success = self.motor.connect(myport, settings)
         self.assertTrue(success)
 
     def tearDown(self):

--- a/tests/opentrons_sdk/drivers/test_virtual_smoothie.py
+++ b/tests/opentrons_sdk/drivers/test_virtual_smoothie.py
@@ -9,10 +9,16 @@ class VirtualSmoothieTestCase(unittest.TestCase):
 
     def setUp(self):
         settings = {
-            'ot_version': 'one_pro',
-            'alpha_steps_per_mm': 80.0
+            'limit_switches': True,
+            'firmware': 'v1.0.5',
+            'config': {
+                'ot_version': 'one_pro',
+                'version': 'v1.0.3',        # config version
+                'alpha_steps_per_mm': 80.0,
+                'beta_steps_per_mm': 80.0
+            }
         }
-        self.s = VirtualSmoothie('v1.0.5', settings)
+        self.s = VirtualSmoothie(settings)
 
     def test_version(self):
         self.s.write('version')

--- a/tests/opentrons_sdk/helpers/test_helpers.py
+++ b/tests/opentrons_sdk/helpers/test_helpers.py
@@ -15,7 +15,7 @@ class HelpersTest(unittest.TestCase):
         self.assertEquals(len(res), 5)
 
         p1 = Vector(10, -12, 14)
-        res = break_down_travel(p1, mode='relative')
+        res = break_down_travel(Vector(0, 0, 0), p1, mode='relative')
         expected = Vector(
             0.46537410754407676,
             -0.5584489290528921,

--- a/tests/opentrons_sdk/labware/test_magbead.py
+++ b/tests/opentrons_sdk/labware/test_magbead.py
@@ -10,7 +10,17 @@ class MagbeadTest(unittest.TestCase):
 
     def setUp(self):
         self.robot = Robot.reset()
-        self.robot.connect()
+        options = {
+            'limit_switches': False,
+            'firmware': 'v1.0.5',
+            'config': {
+                'ot_version': 'one_pro',
+                'version': 'v1.0.3',        # config version
+                'alpha_steps_per_mm': 80.0,
+                'beta_steps_per_mm': 80.0
+            }
+        }
+        self.robot.connect(options=options)
         self.robot.home()
 
         self.plate = containers.load('96-flat', 'A2')

--- a/tests/opentrons_sdk/labware/test_pipette.py
+++ b/tests/opentrons_sdk/labware/test_pipette.py
@@ -15,7 +15,17 @@ class PipetteTest(unittest.TestCase):
 
     def setUp(self):
         self.robot = Robot.reset()
-        self.robot.connect()
+        options = {
+            'limit_switches': True,
+            'firmware': 'v1.0.5',
+            'config': {
+                'ot_version': 'one_pro',
+                'version': 'v1.0.3',        # config version
+                'alpha_steps_per_mm': 80.0,
+                'beta_steps_per_mm': 80.0
+            }
+        }
+        self.robot.connect(options=options)
         self.robot.home()
 
         self.trash = containers.load('point', 'A1')

--- a/tests/opentrons_sdk/performance/test_performance.py
+++ b/tests/opentrons_sdk/performance/test_performance.py
@@ -17,7 +17,17 @@ class PerformanceTest(unittest.TestCase):
         robot = Robot.get_instance()
         robot.get_serial_ports_list()
 
-        robot.connect()
+        options = {
+            'limit_switches': True,
+            'firmware': 'v1.0.5',
+            'config': {
+                'ot_version': 'one_pro',
+                'version': 'v1.0.3',        # config version
+                'alpha_steps_per_mm': 80.0,
+                'beta_steps_per_mm': 80.0
+            }
+        }
+        robot.connect(options=options)
         robot.home()
 
         tiprack = containers.load(

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -9,7 +9,18 @@ class RobotTest(unittest.TestCase):
     def setUp(self):
         Robot.reset()
         self.robot = Robot.get_instance()
-        self.robot.connect()
+
+        options = {
+            'limit_switches': True,
+            'firmware': 'v1.0.5',
+            'config': {
+                'ot_version': 'one_pro',
+                'version': 'v1.0.3',        # config version
+                'alpha_steps_per_mm': 80.0,
+                'beta_steps_per_mm': 80.0
+            }
+        }
+        self.robot.connect(options=options)
         self.robot.home(now=True)
         self.robot.clear()
 


### PR DESCRIPTION
This PR:

1. Fixes a bug in `helpers.break_down_travel `
2. Add more configuration options to the VirtualSmoothie, including disabling limit switches
3. Adds the `now=False` default argument to all `go_to` and `move_to` methods, so that when they're included within a queued Command, you must call `move_to(location, now=True)` so those movements aren't also queued

```python
p200.move_to(plate[0])                # will be queued
p200.move_to(plate[0], now=True)      # will NOT be queued
```
