### PR TITLE
adds top() and bottom() to placeable

### DIFF
--- a/opentrons_sdk/containers/placeable.py
+++ b/opentrons_sdk/containers/placeable.py
@@ -239,6 +239,14 @@ class Placeable(object):
     def center(self, reference=None):
         return self.from_center(x=0.0, y=0.0, z=0.0, reference=reference)
 
+    def bottom(self, z=0):
+        coordinates = self.from_center(x=0, y=0, z=-1)
+        return (self, coordinates + (0, 0, z))
+
+    def top(self, z=0):
+        coordinates = self.from_center(x=0, y=0, z=1)
+        return (self, coordinates + (0, 0, z))
+
     def from_cartesian(self, x, y, z):
         center = self.size() / 2.0
         return center + center * Vector(x, y, z)

--- a/tests/opentrons_sdk/containers/test_placeable.py
+++ b/tests/opentrons_sdk/containers/test_placeable.py
@@ -6,14 +6,15 @@ from opentrons_sdk.containers.placeable import (
     Well,
     Deck,
     Slot)
+from opentrons_sdk.util.vector import Vector
 
 
 class PlaceableTestCase(unittest.TestCase):
-    def generate_plate(self, wells, cols, spacing, offset, radius):
+    def generate_plate(self, wells, cols, spacing, offset, radius, height=0):
         c = Container()
 
         for i in range(0, wells):
-            well = Well(properties={'radius': radius})
+            well = Well(properties={'radius': radius, 'height': height})
             row, col = divmod(i, cols)
             name = chr(row + ord('A')) + str(1 + col)
             coordinates = (col * spacing[0] + offset[0],
@@ -145,3 +146,24 @@ class PlaceableTestCase(unittest.TestCase):
                     ('<Well B1>', (60.0, 65.0, 50.0)),
                     ('<Container A2>', (50.0, 50.0, 50.0))]
         self.assertListEqual(actual, expected)
+
+    def test_top_bottom(self):
+        deck = Deck()
+        slot = Slot()
+        plate = self.generate_plate(
+            wells=4,
+            cols=2,
+            spacing=(10, 10),
+            offset=(0, 0),
+            radius=5,
+            height=10
+        )
+        deck.add(slot, 'A1', (0, 0, 0))
+        slot.add(plate)
+
+        self.assertEqual(
+            plate['A1'].bottom(10),
+            (plate['A1'], Vector(5, 5, 10)))
+        self.assertEqual(
+            plate['A1'].top(10),
+            (plate['A1'], Vector(5, 5, 20)))


### PR DESCRIPTION
In this PR:
In order to make aspirate and dispense relative to top/bottom look nicer we've added `top()` and `bottom()` to placeable that returns (Placeable, Vector) which will make aspirate/dispense look like: `p200.dispense(100, well.top(5))` which would mean dispense 5mm above the top of a well.