### PR TITLE
Change run() to default to live

### DIFF
--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -247,7 +247,7 @@ class Robot(object):
     def actions(self):
         return copy.deepcopy(self._commands)
 
-    def run(self, mode='simulate'):
+    def run(self, mode='live'):
 
         self.set_connection(mode)
 


### PR DESCRIPTION
Hey all -
I'm not actually sure what the "right" behavior for this would be. I was confused when first setting up the SDK -- I connected to a real robot, ran `robot.home()`, then `robot.run()` without anything happening. This is because `run()` defaults to simulation. I would expect that `run()` would default to live mode. This PR just defaults to live mode.

I would love to hear opinions re what "simulation" should accomplish -- we can already simulate runs by initializing a Robot instance without a port name, but is it useful to be able to simulate on-the-fly by switching out the _driver?

I'm new to the codebase and just reading through it, so I appreciate y'all bearing with me in advance!