### PR TITLE
158 s add pipette warnings to robot warnings

### DIFF
--- a/opentrons_sdk/instruments/pipette.py
+++ b/opentrons_sdk/instruments/pipette.py
@@ -478,7 +478,7 @@ class Pipette(Instrument):
         if volume > self.max_volume:
             raise RuntimeError(
                 "{0}µl exceeds pipette's maximum volume ({1}ul).".format(
-                    volume, max_volume))
+                    volume, self.max_volume))
         if volume < self.min_volume:
             self.robot.add_warning(
                 "{0}µl is less than pipette's min_volume ({1}ul).".format(

--- a/opentrons_sdk/instruments/pipette.py
+++ b/opentrons_sdk/instruments/pipette.py
@@ -124,7 +124,7 @@ class Pipette(Instrument):
             self.position_for_aspirate(location)
 
             self.current_volume += volume
-            distance, _ = self.plunge_distance(self.current_volume)
+            distance = self.plunge_distance(self.current_volume)
             destination = self.positions['bottom'] - distance
 
             speed = self.speeds['aspirate'] * rate
@@ -158,7 +158,7 @@ class Pipette(Instrument):
 
             if volume:
                 self.current_volume -= volume
-                distance, _ = self.plunge_distance(self.current_volume)
+                distance = self.plunge_distance(self.current_volume)
                 destination = self.positions['bottom'] - distance
 
                 speed = self.speeds['dispense'] * rate
@@ -190,33 +190,7 @@ class Pipette(Instrument):
                 location = location.bottom(1)
             self.move_to(location, strategy='direct', now=True)
 
-    def transfer(self, source, destination, volume=None):
-        volume = volume or self.max_volume
-        self.aspirate(volume, source)
-        self.dispense(volume, destination)
-        return self
-
-    def distribute(self, source, destinations, volume=None, extra_pull=0):
-        volume = volume or self.max_volume
-        fractional_volume = volume / len(destinations)
-
-        self.aspirate(volume + extra_pull, source)
-        for well in destinations:
-            self.dispense(fractional_volume, well)
-
-        return self
-
-    def consolidate(self, destination, sources, volume=None):
-        volume = volume or self.max_volume
-        fractional_volume = (volume) / len(sources)
-
-        for well in sources:
-            self.aspirate(fractional_volume, well)
-
-        self.dispense(volume, destination)
-        return self
-
-    def mix(self, volume, repetitions, location=None):
+    def mix(self, volume, repetitions=1, location=None):
         def _do():
             # plunger movements are handled w/ aspirate/dispense
             # using Command for printing description
@@ -281,6 +255,7 @@ class Pipette(Instrument):
     def return_tip(self):
         def _do():
             if not self.current_tip_home_well:
+                self.robot.add_warning('Pipette has no tip to return')
                 return
 
             self.drop_tip(self.current_tip_home_well)
@@ -293,8 +268,13 @@ class Pipette(Instrument):
         def _do():
             nonlocal location
 
-            if not location and self.has_tip_rack():
-                location = next(self.tip_rack_iter)
+            if not location:
+                if self.has_tip_rack():
+                    # TODO: raise warning/exception if looped back to first tip
+                    location = next(self.tip_rack_iter)
+                else:
+                    self.robot.warning(
+                        'pick_up_tip called with no reference to a tip')
 
             if location:
                 placeable, _ = containers.unpack_location(location)
@@ -305,7 +285,6 @@ class Pipette(Instrument):
             # TODO: actual plunge depth for picking up a tip
             # varies based on the tip
             # right now it's accounted for via plunge depth
-            # TODO: Need to talk about containers z positioning
             tip_plunge = 6
 
             # Dip into tip and pull it up
@@ -313,7 +292,6 @@ class Pipette(Instrument):
                 self.robot.move_head(z=-tip_plunge, mode='relative')
                 self.robot.move_head(z=tip_plunge, mode='relative')
 
-            self.robot.home('z', now=True)
         description = "Picking up tip from {0}".format(
             (humanize_location(location) if location else '<In Place>')
         )
@@ -340,9 +318,49 @@ class Pipette(Instrument):
         self.robot.add_command(Command(do=_do, description=description))
         return self
 
+    def home(self):
+        def _do():
+            self.plunger.home()
+            self.current_volume = 0
+
+        description = "Homing pipette plunger on axis {}".format(self.axis)
+        self.robot.add_command(Command(do=_do, description=description))
+        return self
+
+    def transfer(self, volume, source, destination=None):
+        if not isinstance(volume, (int, float, complex)):
+            if volume and not destination:
+                destination = source
+                source = volume
+            volume = None
+
+        self.aspirate(volume, source)
+        self.dispense(volume, destination)
+        return self
+
+    def distribute(self, volume, source, destinations):
+        volume = volume or self.max_volume
+        fractional_volume = volume / len(destinations)
+
+        self.aspirate(volume, source)
+        for well in destinations:
+            self.dispense(fractional_volume, well)
+
+        return self
+
+    def consolidate(self, volume, sources, destination):
+        volume = volume or self.max_volume
+        fractional_volume = (volume) / len(sources)
+
+        for well in sources:
+            self.aspirate(fractional_volume, well)
+
+        self.dispense(volume, destination)
+        return self
+
     def calibrate(self, position):
         current_position = self.robot._driver.get_plunger_position()
-        current_position = current_position['current'][self.axis]
+        current_position = current_position['target'][self.axis]
         kwargs = {}
         kwargs[position] = current_position
         self.calibrate_plunger(**kwargs)
@@ -405,6 +423,12 @@ class Pipette(Instrument):
     def set_max_volume(self, max_volume):
         self.max_volume = max_volume
 
+        if self.max_volume <= self.min_volume:
+            raise RuntimeError(
+                'Pipette max volume is less than '
+                'min volume ({0} < {1})'.format(
+                    self.max_volume, self.min_volume))
+
         self.update_calibrations()
 
         return self
@@ -418,13 +442,14 @@ class Pipette(Instrument):
         Calibration of the top and bottom positions are necessary for
         these calculations to work.
         """
-        if self.positions['bottom'] is None or self.positions['top'] is None:
-            raise ValueError(
-                "Pipette {} not calibrated.".format(self.axis)
-            )
-        (percent, warnings) = self._volume_percentage(volume)
+        percent = self._volume_percentage(volume)
         travel = self.positions['bottom'] - self.positions['top']
-        return (travel * percent, warnings)
+        if (travel < 0 or
+            not (self.positions['bottom'] <
+                 self.positions['blow_out'] <
+                 self.positions['drop_tip'])):
+            raise RuntimeError('Plunger calibrated incorrectly')
+        return travel * percent
 
     def _volume_percentage(self, volume):
         """Returns the plunger percentage for a given volume.
@@ -432,15 +457,20 @@ class Pipette(Instrument):
         We use this to calculate what actual position the plunger axis
         needs to be at in order to achieve the correct volume of liquid.
         """
-        warning_msg = None
         if volume < 0:
-            warning_msg = "Volume must be a positive number."
+            raise RuntimeError(
+                "Volume must be a positive number, got {}.".format(volume))
+            volume = 0
         if volume > self.max_volume:
-            warning_msg = "{}µl exceeds maximum volume.".format(volume)
+            raise RuntimeError(
+                "{0}µl exceeds pipette's maximum volume ({1}ul).".format(
+                    volume, max_volume))
         if volume < self.min_volume:
-            warning_msg = "{}µl is too small.".format(volume)
+            self.robot.add_warning(
+                "{0}µl is less than pipette's min_volume ({1}ul).".format(
+                    volume, self.min_volume))
 
-        return (volume / self.max_volume, warning_msg)
+        return volume / self.max_volume
 
     def delay(self, seconds):
         def _do():

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -255,6 +255,11 @@ class Robot(object):
 
         self._runtime_warnings = []
 
+        if not self._instruments:
+            self.add_warning('No instruments added to robot')
+        if not self._commands:
+            self.add_warning('No commands added to robot')
+
         for instrument in self._instruments.values():
             instrument.reset()
 
@@ -287,6 +292,8 @@ class Robot(object):
             connection = self.connections[mode]
             if connection:
                 self._driver.connect(connection)
+            else:
+                self._driver.disconnect()
         else:
             raise ValueError(
                 'mode expected to be "live" or "simulate", '

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -283,8 +283,17 @@ class Robot(object):
             self.set_connection('simulate_switches')
         else:
             self.set_connection('simulate')
+
+        for instrument in self._instruments.values():
+            instrument.set_plunger_defaults()
+
         res = self.run()
+
         self.set_connection('live')
+
+        for instrument in self._instruments.values():
+            instrument.restore_plunger_positions()
+
         return res
 
     def set_connection(self, mode):

--- a/opentrons_sdk/robot/robot.py
+++ b/opentrons_sdk/robot/robot.py
@@ -248,8 +248,7 @@ class Robot(object):
     def actions(self):
         return copy.deepcopy(self._commands)
 
-    def run(self):
-
+    def prepare_for_run(self):
         if not self._driver.connection:
             raise RuntimeWarning('Please connect to the robot')
 
@@ -262,6 +261,10 @@ class Robot(object):
 
         for instrument in self._instruments.values():
             instrument.reset()
+
+    def run(self):
+
+        self.prepare_for_run()
 
         for command in self._commands:
             try:

--- a/opentrons_sdk/util/log.py
+++ b/opentrons_sdk/util/log.py
@@ -29,7 +29,7 @@ logging_config = dict(
     },
     root={
         'handlers': ['file'],
-        'level': logging.DEBUG
+        'level': logging.CRITICAL
     },
 )
 dictConfig(logging_config)

--- a/opentrons_sdk/util/log.py
+++ b/opentrons_sdk/util/log.py
@@ -29,7 +29,7 @@ logging_config = dict(
     },
     root={
         'handlers': ['file'],
-        'level': logging.CRITICAL
+        'level': logging.DEBUG
     },
 )
 dictConfig(logging_config)

--- a/tests/opentrons_sdk/labware/test_pipette.py
+++ b/tests/opentrons_sdk/labware/test_pipette.py
@@ -474,25 +474,25 @@ class PipetteTest(unittest.TestCase):
     def test_tip_tracking_chain(self):
         self.p200.move_to = mock.Mock()
 
-        # for _ in range(0, 96 * 4):
-        #     self.p200.pick_up_tip()
+        for _ in range(0, 96 * 4):
+            self.p200.pick_up_tip()
 
-        # expected = []
-        # for i in range(0, 96):
-        #     expected.append(self.build_move_to_bottom(self.tiprack1[i]))
-        # for i in range(0, 96):
-        #     expected.append(self.build_move_to_bottom(self.tiprack2[i]))
-        # for i in range(0, 96):
-        #     expected.append(self.build_move_to_bottom(self.tiprack1[i]))
-        # for i in range(0, 96):
-        #     expected.append(self.build_move_to_bottom(self.tiprack2[i]))
+        expected = []
+        for i in range(0, 96):
+            expected.append(self.build_move_to_bottom(self.tiprack1[i]))
+        for i in range(0, 96):
+            expected.append(self.build_move_to_bottom(self.tiprack2[i]))
+        for i in range(0, 96):
+            expected.append(self.build_move_to_bottom(self.tiprack1[i]))
+        for i in range(0, 96):
+            expected.append(self.build_move_to_bottom(self.tiprack2[i]))
 
-        # self.robot.simulate()
+        self.robot.simulate()
 
-        # self.assertEqual(
-        #     self.p200.move_to.mock_calls,
-        #     expected
-        # )
+        self.assertEqual(
+            self.p200.move_to.mock_calls,
+            expected
+        )
 
     def test_tip_tracking_chain_multi_channel(self):
         p200_multi = instruments.Pipette(

--- a/tests/opentrons_sdk/protocol/test_robot.py
+++ b/tests/opentrons_sdk/protocol/test_robot.py
@@ -27,7 +27,7 @@ class RobotTest(unittest.TestCase):
 
     def test_simulate(self):
         self.robot.disconnect()
-        p200 = instruments.Pipette('b')
+        p200 = instruments.Pipette(axis='b', name='my-fancy-pancy-pipette')
         p200.aspirate().dispense()
         self.robot.simulate()
         self.assertEquals(len(self.robot._commands), 2)


### PR DESCRIPTION
This PR:

1. has the Pipette adding warnings to the Robot during a protocol run
2. the Robot also adds warnings during protocol run
3. slightly modifies transfer, consolidate, and distribute so the arguments are similar to other methods
4. instantiates plunger positions to `None`, and allows simulating a protocol without calibrating the pipette plungers